### PR TITLE
Added primitive "DoubleFromParts", for use in a lexer for doubles.

### DIFF
--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/ErrorCodeNames_en.properties
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/ErrorCodeNames_en.properties
@@ -1,6 +1,6 @@
 #
 # ErrorCodeNames_en.properties
-# Copyright © 1993-2019, The Avail Foundation, LLC.
+# Copyright © 1993-2020, The Avail Foundation, LLC.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/PrimitiveNames_en.properties
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/PrimitiveNames_en.properties
@@ -1,6 +1,6 @@
 #
 # PrimitiveNames_en.properties
-# Copyright © 1993-2019, The Avail Foundation, LLC.
+# Copyright © 1993-2020, The Avail Foundation, LLC.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -1341,6 +1341,31 @@ P_DoubleFromLongBits_comment=\
 \ *        A 64-bit signed integer.\n\
 \ * @returns "{3}"\n\
 \ *    The double having the specified bit representation.\n\
+\ */\n
+# DoubleFromParts : _=4
+P_DoubleFromParts=
+P_DoubleFromParts_1=wholePart
+P_DoubleFromParts_2=fractionPart
+P_DoubleFromParts_3=exponentSign
+P_DoubleFromParts_4=exponentPart
+P_DoubleFromParts_comment=\
+/**\n\
+\ * Given non-empty digit strings for a floating point number's whole number part,\n\
+\ * fractional part, and exponent, and a boolean that's true for a positive\n\
+\ * exponent and false for a negative exponent, construct the corresponding * double.\n\
+\ *\n\
+\ * @category "Primitives"\n\
+\ * @method "{0}"\n\
+\ * @param "{1}" "{5}"\n\
+\ *        The digits before the decimal point.\n\
+\ * @param "{2}" "{6}"\n\
+\ *        The digits immediately after the decimal point.\n\
+\ * @param "{3}" "{7}"\n\
+\ *        A boolean indicating a positive exponent.\n\
+\ * @param "{4}" "{8}"\n\
+\ *        The digits of the exponent.\n\
+\ * @returns "{9}"\n\
+\ *    The non-negative double constructed from the given digits.\n\
 \ */\n
 # DoubleLn : _=1
 P_DoubleLn=ln_

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/SpecialObjectNames_en.properties
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/SpecialObjectNames_en.properties
@@ -2515,7 +2515,7 @@ specialObject170_comment=\
 \ */\n
 # <¢[0-9]ᵀ…|1..∞>
 specialObject171=non-empty string of digits
-specialObject171_type=¢[0-9]+
+specialObject171_type=¢[0-9]ᵀ+
 specialObject171_comment=\
 /**\n\
 \ * The type for non-empty strings composed entirely of digit characters.\n\

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/SpecialObjectNames_en.properties
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/SpecialObjectNames_en.properties
@@ -1,6 +1,6 @@
 #
 # SpecialObjectNames_en.properties
-# Copyright © 1993-2019, The Avail Foundation, LLC.
+# Copyright © 1993-2020, The Avail Foundation, LLC.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -2508,6 +2508,17 @@ specialObject170_type=$[…]→⊤
 specialObject170_comment=\
 /**\n\
 \ * The continuation type for continuations based on ⊤-valued functions.\n\
+\ *\n\
+\ * @category "Primitives" "Types"\n\
+\ * @type "{1}"\n\
+\ * @alias "{0}"\n\
+\ */\n
+# <¢[0-9]ᵀ…|1..∞>
+specialObject171=non-empty string of digits
+specialObject171_type=¢[0-9]+
+specialObject171_comment=\
+/**\n\
+\ * The type for non-empty strings composed entirely of digit characters.\n\
 \ *\n\
 \ * @category "Primitives" "Types"\n\
 \ * @type "{1}"\n\

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Bootstrap.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Bootstrap.avail
@@ -1,6 +1,6 @@
 /*
  * Bootstrap.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Error Codes.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Error Codes.avail
@@ -1,6 +1,6 @@
 /*
  * Error Codes.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Fallible Primitives.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Fallible Primitives.avail
@@ -1,6 +1,6 @@
 /*
  * Fallible Primitives.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Infallible Primitives.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Infallible Primitives.avail
@@ -1,6 +1,6 @@
 /*
  * Infallible Primitives.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Origin.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Origin.avail
@@ -1,6 +1,6 @@
 /*
  * Origin.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Primitives.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Primitives.avail
@@ -1,6 +1,6 @@
 /*
  * Primitives.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Special Objects.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Special Objects.avail
@@ -1,6 +1,6 @@
 /*
  * Special Objects.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,6 +128,7 @@ Names
 	/*  37 */ "natural number",
 	/*  97 */ "non-empty map",
 	/*  99 */ "non-empty set",
+	/* 171 */ "non-empty string of digits",
 	/* 136 */ "nonempty set of atom",
 	/* 135 */ "nonempty set of string",
 	/* 133 */ "nonempty string",
@@ -2236,4 +2237,13 @@ Special object "character type number" is special object 169;
  * @alias "continuation returning top"
  */
 Special object "continuation returning top" is special object 170;
+
+/**
+ * The type for non-empty strings composed entirely of digit characters.
+ *
+ * @category "Primitives" "Types"
+ * @type "¢[0-9]+"
+ * @alias "non-empty string of digits"
+ */
+Special object "non-empty string of digits" is special object 171;
 

--- a/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Special Objects.avail
+++ b/avail-bootstrap/src/main/java/com/avail/tools/bootstrap/generated/en/Bootstrap.avail/Special Objects.avail
@@ -2242,7 +2242,7 @@ Special object "continuation returning top" is special object 170;
  * The type for non-empty strings composed entirely of digit characters.
  *
  * @category "Primitives" "Types"
- * @type "¢[0-9]+"
+ * @type "¢[0-9]ᵀ+"
  * @alias "non-empty string of digits"
  */
 Special object "non-empty string of digits" is special object 171;

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Bootstrap.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Bootstrap.avail
@@ -1,6 +1,6 @@
 /*
  * Bootstrap.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Error Codes.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Error Codes.avail
@@ -1,6 +1,6 @@
 /*
  * Error Codes.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Fallible Primitives.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Fallible Primitives.avail
@@ -1,6 +1,6 @@
 /*
  * Fallible Primitives.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Infallible Primitives.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Infallible Primitives.avail
@@ -1,6 +1,6 @@
 /*
  * Infallible Primitives.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Origin.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Origin.avail
@@ -1,6 +1,6 @@
 /*
  * Origin.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Primitives.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Primitives.avail
@@ -1,6 +1,6 @@
 /*
  * Primitives.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Special Objects.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Special Objects.avail
@@ -1,6 +1,6 @@
 /*
  * Special Objects.avail
- * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * Copyright © 1993-2020, The Avail Foundation, LLC.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -128,6 +128,7 @@ Names
 	/*  37 */ "natural number",
 	/*  97 */ "non-empty map",
 	/*  99 */ "non-empty set",
+	/* 171 */ "non-empty string of digits",
 	/* 136 */ "nonempty set of atom",
 	/* 135 */ "nonempty set of string",
 	/* 133 */ "nonempty string",
@@ -2236,4 +2237,13 @@ Special object "character type number" is special object 169;
  * @alias "continuation returning top"
  */
 Special object "continuation returning top" is special object 170;
+
+/**
+ * The type for non-empty strings composed entirely of digit characters.
+ *
+ * @category "Primitives" "Types"
+ * @type "¢[0-9]+"
+ * @alias "non-empty string of digits"
+ */
+Special object "non-empty string of digits" is special object 171;
 

--- a/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Special Objects.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Special Objects.avail
@@ -2242,7 +2242,7 @@ Special object "continuation returning top" is special object 170;
  * The type for non-empty strings composed entirely of digit characters.
  *
  * @category "Primitives" "Types"
- * @type "¢[0-9]+"
+ * @type "¢[0-9]ᵀ+"
  * @alias "non-empty string of digits"
  */
 Special object "non-empty string of digits" is special object 171;

--- a/src/main/java/com/avail/AvailRuntime.java
+++ b/src/main/java/com/avail/AvailRuntime.java
@@ -1061,8 +1061,7 @@ public final class AvailRuntime
 		specials[74] = zeroOrMoreOf(
 			setTypeForSizesContentType(wholeNumbers(), stringType()));
 		specials[75] = setTypeForSizesContentType(wholeNumbers(), stringType());
-		specials[76] =
-			functionType(tuple(naturalNumbers()), bottom());
+		specials[76] = functionType(tuple(naturalNumbers()), bottom());
 		specials[77] = emptySet();
 		specials[78] = negativeInfinity();
 		specials[79] = positiveInfinity();
@@ -1181,6 +1180,7 @@ public final class AvailRuntime
 		specials[169] = inclusive(0L, 31L);
 		specials[170] =
 			continuationTypeForFunctionType(functionTypeReturning(TOP.o()));
+		specials[171] = CharacterDescriptor.nonemptyStringOfDigitsType;
 
 		// DO NOT CHANGE THE ORDER OF THESE ENTRIES!  Serializer compatibility
 		// depends on the order of this list.

--- a/src/main/java/com/avail/descriptor/CharacterDescriptor.java
+++ b/src/main/java/com/avail/descriptor/CharacterDescriptor.java
@@ -41,9 +41,12 @@ import com.avail.utility.json.JSONWriter;
 import javax.annotation.Nullable;
 import java.util.IdentityHashMap;
 
+import static com.avail.descriptor.AbstractEnumerationTypeDescriptor.enumerationWith;
 import static com.avail.descriptor.CharacterDescriptor.IntegerSlots.CODE_POINT;
 import static com.avail.descriptor.IntegerDescriptor.computeHashOfInt;
 import static com.avail.descriptor.ObjectTupleDescriptor.tuple;
+import static com.avail.descriptor.StringDescriptor.stringFrom;
+import static com.avail.descriptor.TupleTypeDescriptor.oneOrMoreOf;
 import static com.avail.descriptor.TypeDescriptor.Types.CHARACTER;
 
 /**
@@ -361,4 +364,12 @@ extends Descriptor
 
 	/** The maximum code point value as an {@code int}. */
 	public static final int maxCodePointInt = Character.MAX_CODE_POINT;
+
+	/** A type that contains all ASCII decimal digit characters. */
+	public static final A_Type digitsType =
+		enumerationWith(stringFrom("0123456789").asSet()).makeShared();
+
+	/** The type for non-empty strings of ASCII decimal digits. */
+	public static final A_Type nonemptyStringOfDigitsType =
+		oneOrMoreOf(digitsType);
 }

--- a/src/main/kotlin/com/avail/interpreter/primitive/doubles/P_DoubleFromParts.kt
+++ b/src/main/kotlin/com/avail/interpreter/primitive/doubles/P_DoubleFromParts.kt
@@ -1,0 +1,103 @@
+/*
+ * P_DoubleFromParts.kt
+ * Copyright © 1993-2019, The Avail Foundation, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of the contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.avail.interpreter.primitive.doubles
+
+import com.avail.descriptor.A_Number
+import com.avail.descriptor.A_Type
+import com.avail.descriptor.CharacterDescriptor.nonemptyStringOfDigitsType
+import com.avail.descriptor.DoubleDescriptor.fromDouble
+import com.avail.descriptor.EnumerationTypeDescriptor.booleanType
+import com.avail.descriptor.FunctionTypeDescriptor.functionType
+import com.avail.descriptor.ObjectTupleDescriptor.tuple
+import com.avail.descriptor.TypeDescriptor.Types.DOUBLE
+import com.avail.descriptor.tuples.A_String
+import com.avail.interpreter.Interpreter
+import com.avail.interpreter.Primitive
+import com.avail.interpreter.Primitive.Flag.*
+
+/**
+ * **Primitive:** Construct a non-negative [double][A_Number] from parts
+ * supplied primarily as [strings][A_String] of digits.
+ *
+ * @author Mark van Gulik &lt;mark@availlang.org&gt;
+ * @author Todd L Smith &lt;todd@availlang.org&gt;
+ */
+@Suppress("unused")
+object P_DoubleFromParts : Primitive(4, CannotFail, CanInline, CanFold)
+{
+	override fun attempt(interpreter: Interpreter): Result
+	{
+		interpreter.checkArgumentCount(4)
+		val (wholePart, fractionPart, exponentSign, exponentPart) =
+			interpreter.argsBuffer
+
+		// Since we expect that this primitive will only be used for building
+		// floating-point literals, it doesn't need to be particularly
+		// efficient. We therefore convert the different parts to strings,
+		// compose a floating-point numeral, and then ask Java to parse and
+		// convert. This is less efficient than doing the work ourselves, but
+		// gives us the opportunity to leverage well-tested and tuned Java
+		// library code.
+		val numeral =
+			wholePart.asNativeString() +
+				"." +
+				fractionPart.asNativeString() +
+				"e" +
+				when {
+					exponentSign.extractBoolean() -> ""
+					else -> "-"} +
+			    exponentPart.asNativeString()
+		val result: A_Number
+		try
+		{
+			result = fromDouble(java.lang.Double.valueOf(numeral))
+		}
+		catch (e: NumberFormatException)
+		{
+			assert(false) {
+				"This shouldn't happen, since we control the numeral!"
+			}
+			throw e
+		}
+		return interpreter.primitiveSuccess(result)
+	}
+
+	override fun privateBlockTypeRestriction(): A_Type =
+		functionType(
+			tuple(
+				nonemptyStringOfDigitsType,
+				nonemptyStringOfDigitsType,
+				booleanType(),
+				nonemptyStringOfDigitsType),
+			DOUBLE.o())
+}


### PR DESCRIPTION
Adds the primitive "DoubleFromParts" that takes the whole part digit string, the fractional part digit string, a boolean that's true for a positive exponent and false for a negative exponent, and an exponent digit string.  This is to assist Leslie's work on a lexer for doubles.  The float lexer will be similar, but end with a call to "_→float".