### PR TITLE
Prevent index out of bounds with bad CLI argument

### DIFF
--- a/avail-workbench/src/main/kotlin/com/avail/environment/AvailWorkbench.kt
+++ b/avail-workbench/src/main/kotlin/com/avail/environment/AvailWorkbench.kt
@@ -2878,6 +2878,14 @@ class AvailWorkbench internal constructor (val resolver: ModuleNameResolver)
 										workbench.moduleTree
 											.getRowForPath(path))
 								}
+								else
+								{
+									workbench.writeText(
+										format(
+											"Command line argument '%s' was not a valid module path",
+											initial),
+										ERR)
+								}
 							}
 							workbench.backgroundTask = null
 							workbench.setEnablements()

--- a/avail-workbench/src/main/kotlin/com/avail/environment/AvailWorkbench.kt
+++ b/avail-workbench/src/main/kotlin/com/avail/environment/AvailWorkbench.kt
@@ -1403,6 +1403,11 @@ class AvailWorkbench internal constructor (val resolver: ModuleNameResolver)
 	fun modulePath(moduleName: String): TreePath?
 	{
 		val path = moduleName.split('/', '\\')
+		if (path.size < 2)
+		{
+			// Module paths start with a slash, so we need at least 2 segments
+			return null
+		}
 		val model = moduleTree.model
 		val treeRoot = model.root as DefaultMutableTreeNode
 		var nodes: Enumeration<DefaultMutableTreeNode> =

--- a/avail-workbench/src/main/kotlin/com/avail/environment/AvailWorkbench.kt
+++ b/avail-workbench/src/main/kotlin/com/avail/environment/AvailWorkbench.kt
@@ -1403,7 +1403,7 @@ class AvailWorkbench internal constructor (val resolver: ModuleNameResolver)
 	fun modulePath(moduleName: String): TreePath?
 	{
 		val path = moduleName.split('/', '\\')
-		if (path.size < 2)
+		if (path.size < 2 || path[0] != "")
 		{
 			// Module paths start with a slash, so we need at least 2 segments
 			return null

--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,8 @@ clean.dependsOn scrubReleases
 
 // Show the release banner upon final completion of the recursive build.
 gradle.buildFinished {
-	if (!('build' in gradle.startParameter.taskNames))
+	if (!('build' in gradle.startParameter.taskNames)
+		|| it.getFailure() != null)
 	{
 		return
 	}


### PR DESCRIPTION
`avail-dev` passes its first argument to `workbench.modulePath`. If the argument doesn't contain a slash, this can cause an index out of bounds, since the method assumes the string starts with one.

While we're at it, add an error message when the argument fails to resolve to a module path.