### PR TITLE
Add command line flags to avail-dev and avail-server

### DIFF
--- a/distro/bin/avail-config
+++ b/distro/bin/avail-config
@@ -34,8 +34,8 @@
 
 # Make sure that AVAIL_HOME is set.
 if [ "X$AVAIL_HOME" = "X" ]; then
-	echo "Fatal error: AVAIL_HOME is not set."
-	exit 1
+    echo "Fatal error: AVAIL_HOME is not set."
+    exit 1
 fi
 
 # Create a configuration directory if necessary. Fix the permissions if it is
@@ -43,42 +43,42 @@ fi
 AVAIL_USER=$HOME/.avail
 CONFIG=$AVAIL_USER/etc
 if [ ! -e "$CONFIG" ]; then
-	install -d -m 700 "$CONFIG"
+    install -d -m 700 "$CONFIG"
 elif [ ! -d "$CONFIG" ]; then
-	echo "Fatal error: $CONFIG exists but is not a directory."
-	exit 1
+    echo "Fatal error: $CONFIG exists but is not a directory."
+    exit 1
 elif [ ! -r "$CONFIG" -o ! -w "$CONFIG" ]; then
-	chmod u+rw "$CONFIG"
+    chmod u+rw "$CONFIG"
 fi
 
 # Copy the standard configuration file for logging, but only if the user does
 # not already have one in place.
 if [ ! -e "$CONFIG/logging.properties" ]; then
-	cp "$AVAIL_HOME/etc/logging.properties" "$CONFIG/logging.properties"
+    cp "$AVAIL_HOME/etc/logging.properties" "$CONFIG/logging.properties"
 elif [ ! -f "$CONFIG/logging.properties" ]; then
-	echo "Fatal error: $CONFIG/logging.properties exists but is not a regular file"
-	exit 1
+    echo "Fatal error: $CONFIG/logging.properties exists but is not a regular file"
+    exit 1
 fi
 
 # Create an empty renames file, but only if the user does not already have an
 # existing one.
 if [ ! -e "$CONFIG/renames" ]; then
-	touch "$CONFIG/renames"
+    touch "$CONFIG/renames"
 elif [ ! -f "$CONFIG/renames" ]; then
-	echo "Fatal error: $CONFIG/renames exists but it is not a regular file"
-	exit 1
+    echo "Fatal error: $CONFIG/renames exists but it is not a regular file"
+    exit 1
 fi
 
 # Create the repository directory if necessary. Fix the permissions if it is
 # not readable and writable by the current user.
 REPO_DIR=$AVAIL_USER/repos
 if [ ! -e "$REPO_DIR" ]; then
-	install -d -m 700 "$REPO_DIR"
+  install -d -m 700 "$REPO_DIR"
 elif [ ! -d "$REPO_DIR" ]; then
-	echo "Fatal error: $REPO_DIR exists but is not a directory."
-	exit 1
+  echo "Fatal error: $REPO_DIR exists but is not a directory."
+  exit 1
 elif [ ! -r "$REPO_DIR" -o ! -w "$REPO_DIR" ]; then
-	chmod u+rw "$REPO_DIR"
+chmod u+rw "$REPO_DIR"
 fi
 
 USE_EXAMPLE_ROOTS=true
@@ -86,103 +86,110 @@ DRY_RUN=
 FORCE_FOREGROUND=
 declare -a ADDITIONAL_ROOTS
 
-# Read options
-while getopts ":a:cdDfh" opt; do
-  case ${opt} in
-	a )
-	  # [a]dd an entry to the AVAIL_ROOTS list
-	  ADDITIONAL_ROOTS+=( "$OPTARG" )
-	  ;;
-	c )
-	  # add the [c]urrent directory to the AVAIL_ROOTS list
-	  improvised_name="${PWD##*/}"
-	  improvised_name="${improvised_name%%.*}"
-	  improvised_name="local.$USER.${improvised_name// /}"
-	  # the root's name is given as local.username.directoryname
-	  ADDITIONAL_ROOTS+=( "$improvised_name=$REPO_DIR/$improvised_name.repo,$PWD" )
-	  ;;
-	d )
-	  # perform a [d]ry run and output the final command instead of running it
-	  DRY_RUN=true
-	  ;;
-    E )
-	  # omit the [E]xamples in the default roots
-      USE_EXAMPLE_ROOTS=
-      ;;
-	f )
-	  # run in the [f]oreground
-	  FORCE_FOREGROUND=true
-	  ;;
-	h )
-      # print the [h]elp
-	  echo "Usage:" 
-	  echo "  ANY -h"
-	  echo "  avail-dev [-a roots] [-c] [-d] [-E] [-f] [initial_module]"
-	  echo "  avail-server [-a roots] [-c] [-d] [-E] [-f]"
-	  echo "  availc [-a roots] [-c] [-d] [-E]"
-	  echo "Commands:"
-	  echo "  avail-dev    Launch the interactive workbench UI."
-	  echo "  avail-server Launch the avail web server."
-	  echo "  availc       Launch command line avail interface."
-	  echo "Options:"
-	  echo "  -h        Print this help"
-	  echo "  -a ROOTS  Append the given string to the avail roots list, either as set in"
-	  echo "            the corresponding environment variable or in this cmd's defaults."
-	  echo "  -c        Add the current working directory to the avail roots (see above),"
-	  echo "            using local.\$USER.DIRECTORY as its improvised root name."
-	  echo "  -d        Dry run - print the final Java VM invocation instead of running."
-	  echo "  -E        Omit the examples root from the default roots list."
-	  echo "  -f        Force the workbench command to run in the foreground."
-	  exit 0
-	  ;;
-    \? )
-      echo "Unknown option: $OPTARG" 1>&2
-      ;;
-    : )
-      echo "Invalid option: $OPTARG requires an argument" 1>&2
-      ;;
-  esac
-done
-# Remove the parsed arguments
-shift $((OPTIND - 1))
+if [ "$SKIP_OPT" = true ]; then
+    OPTIND=1
+else
+  # Read options
+  while getopts ":a:cdDf?" opt; do
+    case ${opt} in
+      a )
+        # [a]dd an entry to the AVAIL_ROOTS list
+        ADDITIONAL_ROOTS+=( "$OPTARG" )
+        ;;
+      c )
+        # add the [c]urrent directory to the AVAIL_ROOTS list
+        improvised_name="${PWD##*/}"
+        improvised_name="${improvised_name%%.*}"
+        improvised_name="local.$USER.${improvised_name// /}"
+        # the root's name is given as local.username.directoryname
+        ADDITIONAL_ROOTS+=( "$improvised_name=$REPO_DIR/$improvised_name.repo,$PWD" )
+        ;;
+      d )
+        # perform a [d]ry run and output the final command instead of running it
+        DRY_RUN=true
+        ;;
+      E )
+        # omit the [E]xamples in the default roots
+        USE_EXAMPLE_ROOTS=
+        ;;
+      f )
+        # run in the [f]oreground
+        FORCE_FOREGROUND=true
+        ;;
+      \? )
+        if [ "$OPTARG" != "?" ]; then
+          # getopts uses ? to indicate unknown option
+          echo "Unknown option: $OPTARG" 1>&2
+        else
+          # this is a "real" -? flag, so print the [h]elp
+          echo "Usage:" 
+          echo "  ANY -?"
+          echo "  avail-dev [-a roots] [-c] [-d] [-E] [-f] [initial_module]"
+          echo "  avail-server [-a roots] [-c] [-d] [-E] [-f]"
+          echo "  availc ..."
+          echo "Commands:"
+          echo "  avail-dev    Launch the interactive workbench UI."
+          echo "  avail-server Launch the avail web server."
+          echo "  availc       Launch the avail CLI compiler. This tool has its own command"
+          echo "               and argument syntax, viewable with the -? option."
+          echo "Options:"
+          echo "  -?        Print this help."
+          echo "  -a ROOTS  Append the given string to the avail roots list, either as set in"
+          echo "            the corresponding environment variable or in this cmd's defaults."
+          echo "  -c        Add the current working directory to the avail roots (see above),"
+          echo "            using local.\$USER.DIRECTORY as its improvised root name."
+          echo "  -d        Dry run - print the final Java VM invocation instead of running."
+          echo "  -E        Omit the examples root from the default roots list."
+          echo "  -f        Force the workbench command to run in the foreground."
+          exit 0
+        fi
+        ;;
+      : )
+        echo "Invalid option: $OPTARG requires an argument" 1>&2
+        ;;
+    esac
+  done
+  # Remove the parsed arguments
+  shift $((OPTIND - 1))
+fi
 
 
 # If AVAIL_ROOTS is not set, then default it.
 if [ "X$AVAIL_ROOTS" = "X" ]; then
-	AVAIL_ROOTS="avail=$REPO_DIR/avail.repo,$AVAIL_HOME/src/avail"
-	if [ "$USE_EXAMPLE_ROOTS" = true ]; then
-		AVAIL_ROOTS="$AVAIL_ROOTS"';'"examples=$REPO_DIR/examples.repo,$AVAIL_HOME/src/examples"
-	fi
+    AVAIL_ROOTS="avail=$REPO_DIR/avail.repo,$AVAIL_HOME/src/avail"
+    if [ "$USE_EXAMPLE_ROOTS" = true ]; then
+        AVAIL_ROOTS="$AVAIL_ROOTS"';'"examples=$REPO_DIR/examples.repo,$AVAIL_HOME/src/examples"
+    fi
 fi
 # add the additional roots specified by CLI flags
 for r in "${ADDITIONAL_ROOTS[@]}"; do
-	AVAIL_ROOTS="$AVAIL_ROOTS"';'"$r"
+    AVAIL_ROOTS="$AVAIL_ROOTS"';'"$r"
 done
 
 # If AVAIL_RENAMES is not set, then default it.
 if [ "X$AVAIL_RENAMES" = "X" ]; then
-	AVAIL_RENAMES="$CONFIG/renames"
+    AVAIL_RENAMES="$CONFIG/renames"
 fi
 
 # Find the Java virtual machine.
 VM=$(command -v java)
 if [ "X$VM" = "X" ]; then
-	echo "Fatal error: Could not locate the Java virtual machine (java)."
-	exit 1
+    echo "Fatal error: Could not locate the Java virtual machine (java)."
+    exit 1
 fi
 
 # The JVM for Mac OS X understands a few options that make for a prettier dock.
 OSNAME=$(uname -s)
 if [ "$OSNAME" = "Darwin" ]; then
-	OSARGS=-Xdock:name=$(basename "$0")\ -Xdock:icon=$AVAIL_HOME/images/AvailHammer.png
+    OSARGS=-Xdock:name=$(basename "$0")\ -Xdock:icon=$AVAIL_HOME/images/AvailHammer.png
 else
-	OSARGS=
+    OSARGS=
 fi
 
 # These are the system arguments for the Java virtual machine.
 VMARGS=(-Xmx2g -classpath "$AVAIL_HOME/lib" $OSARGS "-Djava.util.logging.config.file=$HOME/.avail/logging.properties" "-DavailRoots=$AVAIL_ROOTS" "-DavailRenames=$AVAIL_RENAMES")
 
 if [ "$DRY_RUN" = true ]; then
-	printf '%b ' "$VM "${VMARGS[@]}" -jar $JAR $* \n\c"
-	exit 0
+    printf '%b ' "$VM "${VMARGS[@]}" -jar $JAR $* \n\c"
+    exit 0
 fi

--- a/distro/bin/avail-config
+++ b/distro/bin/avail-config
@@ -1,0 +1,110 @@
+#!/bin/echo This command is only intended for use by other avail scripts.
+#
+# avail-config
+# Copyright © 1993-2020, The Avail Foundation, LLC.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of the contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+# Make sure that AVAIL_HOME is set.
+if [ "X$AVAIL_HOME" = "X" ]; then
+	echo "Fatal error: AVAIL_HOME is not set."
+	exit 1
+fi
+
+# Create a configuration directory if necessary. Fix the permissions if it is
+# not readable and writable by the current user.
+AVAIL_USER=$HOME/.avail
+CONFIG=$AVAIL_USER/etc
+if [ ! -e "$CONFIG" ]; then
+	install -d -m 700 "$CONFIG"
+elif [ ! -d "$CONFIG" ]; then
+	echo "Fatal error: $CONFIG exists but is not a directory."
+	exit 1
+elif [ ! -r "$CONFIG" -o ! -w "$CONFIG" ]; then
+	chmod u+rw "$CONFIG"
+fi
+
+# Copy the standard configuration file for logging, but only if the user does
+# not already have one in place.
+if [ ! -e "$CONFIG/logging.properties" ]; then
+	cp "$AVAIL_HOME/etc/logging.properties" "$CONFIG/logging.properties"
+elif [ ! -f "$CONFIG/logging.properties" ]; then
+	echo "Fatal error: $CONFIG/logging.properties exists but is not a regular file"
+	exit 1
+fi
+
+# Create an empty renames file, but only if the user does not already have an
+# existing one.
+if [ ! -e "$CONFIG/renames" ]; then
+	touch "$CONFIG/renames"
+elif [ ! -f "$CONFIG/renames" ]; then
+	echo "Fatal error: $CONFIG/renames exists but it is not a regular file"
+	exit 1
+fi
+
+# Create the repository directory if necessary. Fix the permissions if it is
+# not readable and writable by the current user.
+REPOS=$AVAIL_USER/repos
+if [ ! -e "$REPOS" ]; then
+	install -d -m 700 "$REPOS"
+elif [ ! -d "$REPOS" ]; then
+	echo "Fatal error: $REPOS exists but is not a directory."
+	exit 1
+elif [ ! -r "$REPOS" -o ! -w "$REPOS" ]; then
+	chmod u+rw "$REPOS"
+fi
+
+# If AVAIL_ROOTS is not set, then default it.
+if [ "X$AVAIL_ROOTS" = "X" ]; then
+	AVAIL_ROOTS="avail=$REPOS/avail.repo,$AVAIL_HOME/src/avail"';'"examples=$REPOS/examples.repo,$AVAIL_HOME/src/examples"
+fi
+
+# If AVAIL_RENAMES is not set, then default it.
+if [ "X$AVAIL_RENAMES" = "X" ]; then
+	AVAIL_RENAMES="$CONFIG/renames"
+fi
+
+# Find the Java virtual machine.
+VM=$(command -v java)
+if [ "X$VM" = "X" ]; then
+	echo "Fatal error: Could not locate the Java virtual machine (java)."
+	exit 1
+fi
+
+# The JVM for Mac OS X understands a few options that make for a prettier dock.
+OSNAME=$(uname -s)
+if [ "$OSNAME" = "Darwin" ]; then
+	OSARGS=-Xdock:name=$(basename "$0")\ -Xdock:icon=$AVAIL_HOME/images/AvailHammer.png
+else
+	OSARGS=
+fi
+
+# These are the system arguments for the Java virtual machine.
+VMARGS=(-Xmx2g -classpath "$AVAIL_HOME/lib" $OSARGS "-Djava.util.logging.config.file=$HOME/.avail/logging.properties" "-DavailRoots=$AVAIL_ROOTS" "-DavailRenames=$AVAIL_RENAMES")

--- a/distro/bin/avail-config
+++ b/distro/bin/avail-config
@@ -71,20 +71,93 @@ fi
 
 # Create the repository directory if necessary. Fix the permissions if it is
 # not readable and writable by the current user.
-REPOS=$AVAIL_USER/repos
-if [ ! -e "$REPOS" ]; then
-	install -d -m 700 "$REPOS"
-elif [ ! -d "$REPOS" ]; then
-	echo "Fatal error: $REPOS exists but is not a directory."
+REPO_DIR=$AVAIL_USER/repos
+if [ ! -e "$REPO_DIR" ]; then
+	install -d -m 700 "$REPO_DIR"
+elif [ ! -d "$REPO_DIR" ]; then
+	echo "Fatal error: $REPO_DIR exists but is not a directory."
 	exit 1
-elif [ ! -r "$REPOS" -o ! -w "$REPOS" ]; then
-	chmod u+rw "$REPOS"
+elif [ ! -r "$REPO_DIR" -o ! -w "$REPO_DIR" ]; then
+	chmod u+rw "$REPO_DIR"
 fi
+
+USE_EXAMPLE_ROOTS=true
+DRY_RUN=
+FORCE_FOREGROUND=
+declare -a ADDITIONAL_ROOTS
+
+# Read options
+while getopts ":a:cdDfh" opt; do
+  case ${opt} in
+	a )
+	  # [a]dd an entry to the AVAIL_ROOTS list
+	  ADDITIONAL_ROOTS+=( "$OPTARG" )
+	  ;;
+	c )
+	  # add the [c]urrent directory to the AVAIL_ROOTS list
+	  improvised_name="${PWD##*/}"
+	  improvised_name="${improvised_name%%.*}"
+	  improvised_name="local.$USER.${improvised_name// /}"
+	  # the root's name is given as local.username.directoryname
+	  ADDITIONAL_ROOTS+=( "$improvised_name=$REPO_DIR/$improvised_name.repo,$PWD" )
+	  ;;
+	d )
+	  # perform a [d]ry run and output the final command instead of running it
+	  DRY_RUN=true
+	  ;;
+    E )
+	  # omit the [E]xamples in the default roots
+      USE_EXAMPLE_ROOTS=
+      ;;
+	f )
+	  # run in the [f]oreground
+	  FORCE_FOREGROUND=true
+	  ;;
+	h )
+      # print the [h]elp
+	  echo "Usage:" 
+	  echo "  ANY -h"
+	  echo "  avail-dev [-a roots] [-c] [-d] [-E] [-f] [initial_module]"
+	  echo "  avail-server [-a roots] [-c] [-d] [-E] [-f]"
+	  echo "  availc [-a roots] [-c] [-d] [-E]"
+	  echo "Commands:"
+	  echo "  avail-dev    Launch the interactive workbench UI."
+	  echo "  avail-server Launch the avail web server."
+	  echo "  availc       Launch command line avail interface."
+	  echo "Options:"
+	  echo "  -h        Print this help"
+	  echo "  -a ROOTS  Append the given string to the avail roots list, either as set in"
+	  echo "            the corresponding environment variable or in this cmd's defaults."
+	  echo "  -c        Add the current working directory to the avail roots (see above),"
+	  echo "            using local.\$USER.DIRECTORY as its improvised root name."
+	  echo "  -d        Dry run - print the final Java VM invocation instead of running."
+	  echo "  -E        Omit the examples root from the default roots list."
+	  echo "  -f        Force the workbench command to run in the foreground."
+	  exit 0
+	  ;;
+    \? )
+      echo "Unknown option: $OPTARG" 1>&2
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+  esac
+done
+# Remove the parsed arguments
+shift $((OPTIND - 1))
+
 
 # If AVAIL_ROOTS is not set, then default it.
 if [ "X$AVAIL_ROOTS" = "X" ]; then
-	AVAIL_ROOTS="avail=$REPOS/avail.repo,$AVAIL_HOME/src/avail"';'"examples=$REPOS/examples.repo,$AVAIL_HOME/src/examples"
+	AVAIL_ROOTS="avail=$REPO_DIR/avail.repo,$AVAIL_HOME/src/avail"
+	if [ "$USE_EXAMPLE_ROOTS" = true ]; then
+		AVAIL_ROOTS="$AVAIL_ROOTS"';'"examples=$REPO_DIR/examples.repo,$AVAIL_HOME/src/examples"
+	fi
 fi
+# add the additional roots specified by CLI flags
+for r in "${ADDITIONAL_ROOTS[@]}"; do
+	AVAIL_ROOTS="$AVAIL_ROOTS"';'"$r"
+done
 
 # If AVAIL_RENAMES is not set, then default it.
 if [ "X$AVAIL_RENAMES" = "X" ]; then
@@ -108,3 +181,8 @@ fi
 
 # These are the system arguments for the Java virtual machine.
 VMARGS=(-Xmx2g -classpath "$AVAIL_HOME/lib" $OSARGS "-Djava.util.logging.config.file=$HOME/.avail/logging.properties" "-DavailRoots=$AVAIL_ROOTS" "-DavailRenames=$AVAIL_RENAMES")
+
+if [ "$DRY_RUN" = true ]; then
+	printf '%b ' "$VM "${VMARGS[@]}" -jar $JAR $* \n\c"
+	exit 0
+fi

--- a/distro/bin/avail-config
+++ b/distro/bin/avail-config
@@ -84,13 +84,14 @@ fi
 USE_EXAMPLE_ROOTS=true
 DRY_RUN=
 FORCE_FOREGROUND=
+ENABLE_ASSERTIONS=
 declare -a ADDITIONAL_ROOTS
 
 if [ "$SKIP_OPT" = true ]; then
     OPTIND=1
 else
   # Read options
-  while getopts ":a:cdDf?" opt; do
+  while getopts ":a:cdeEf?" opt; do
     case ${opt} in
       a )
         # [a]dd an entry to the AVAIL_ROOTS list
@@ -107,6 +108,10 @@ else
       d )
         # perform a [d]ry run and output the final command instead of running it
         DRY_RUN=true
+        ;;
+      e )
+        # Enable assertions
+        ENABLE_ASSERTIONS=true
         ;;
       E )
         # omit the [E]xamples in the default roots
@@ -139,6 +144,7 @@ else
           echo "  -c        Add the current working directory to the avail roots (see above),"
           echo "            using local.\$USER.DIRECTORY as its improvised root name."
           echo "  -d        Dry run - print the final Java VM invocation instead of running."
+          echo "  -e        Enable Java assertions (passes the -ea flag to the JVM)."
           echo "  -E        Omit the examples root from the default roots list."
           echo "  -f        Force the workbench command to run in the foreground."
           exit 0
@@ -188,6 +194,9 @@ fi
 
 # These are the system arguments for the Java virtual machine.
 VMARGS=(-Xmx2g -classpath "$AVAIL_HOME/lib" $OSARGS "-Djava.util.logging.config.file=$HOME/.avail/logging.properties" "-DavailRoots=$AVAIL_ROOTS" "-DavailRenames=$AVAIL_RENAMES")
+if [ "$ENABLE_ASSERTIONS" = true ]; then
+  VMARGS+=( -ea )
+fi
 
 if [ "$DRY_RUN" = true ]; then
     printf '%b ' "$VM "${VMARGS[@]}" -jar $JAR $* \n\c"

--- a/distro/bin/avail-dev
+++ b/distro/bin/avail-dev
@@ -31,10 +31,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+JAR=$AVAIL_HOME/lib/avail-workbench-1.4-all.jar
+
 source avail-config
 
-# Launch the Avail development environment in the background.
-DEVJAR=$AVAIL_HOME/lib/avail-workbench-1.4-all.jar
-# shellcheck disable=SC2048
-# shellcheck disable=SC2086
-$VM "${VMARGS[@]}" -jar "$DEVJAR" $* &
+# Launch the Avail development environment
+if [ "$FORCE_FOREGROUND" = true ]; then
+    $VM "${VMARGS[@]}" -jar $JAR $*
+else
+	$VM "${VMARGS[@]}" -jar $JAR $* &
+fi

--- a/distro/bin/avail-dev
+++ b/distro/bin/avail-dev
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # avail-dev
-# Copyright © 1993-2019, The Avail Foundation, LLC.
+# Copyright © 1993-2020, The Avail Foundation, LLC.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,85 +31,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-# Make sure that AVAIL_HOME is set.
-if [ "X$AVAIL_HOME" = "X" ]; then
-	echo "Fatal error: AVAIL_HOME is not set."
-	exit 1
-fi
-
-# Create a configuration directory if necessary. Fix the permissions if it is
-# not readable and writable by the current user.
-AVAIL_USER=$HOME/.avail
-CONFIG=$AVAIL_USER/etc
-if [ ! -e "$CONFIG" ]; then
-	install -d -m 700 "$CONFIG"
-elif [ ! -d "$CONFIG" ]; then
-	echo "Fatal error: $CONFIG exists but is not a directory."
-	exit 1
-elif [ ! -r "$CONFIG" -o ! -w "$CONFIG" ]; then
-	chmod u+rw "$CONFIG"
-fi
-
-# Copy the standard configuration file for logging, but only if the user does
-# not already have one in place.
-if [ ! -e "$CONFIG/logging.properties" ]; then
-	cp "$AVAIL_HOME/etc/logging.properties" "$CONFIG/logging.properties"
-elif [ ! -f "$CONFIG/logging.properties" ]; then
-	echo "Fatal error: $CONFIG/logging.properties exists but is not a regular file"
-	exit 1
-fi
-
-# Create an empty renames file, but only if the user does not already have an
-# existing one.
-if [ ! -e "$CONFIG/renames" ]; then
-	touch "$CONFIG/renames"
-elif [ ! -f "$CONFIG/renames" ]; then
-	echo "Fatal error: $CONFIG/renames exists but it is not a regular file"
-	exit 1
-fi
-
-# Create the repository directory if necessary. Fix the permissions if it is
-# not readable and writable by the current user.
-REPOS=$AVAIL_USER/repos
-if [ ! -e "$REPOS" ]; then
-	install -d -m 700 "$REPOS"
-elif [ ! -d "$REPOS" ]; then
-	echo "Fatal error: $REPOS exists but is not a directory."
-	exit 1
-elif [ ! -r "$REPOS" -o ! -w "$REPOS" ]; then
-	chmod u+rw "$REPOS"
-fi
-
-# If AVAIL_ROOTS is not set, then default it.
-if [ "X$AVAIL_ROOTS" = "X" ]; then
-	AVAIL_ROOTS="avail=$REPOS/avail.repo,$AVAIL_HOME/src/avail"';'"examples=$REPOS/examples.repo,$AVAIL_HOME/src/examples"
-fi
-
-# If AVAIL_RENAMES is not set, then default it.
-if [ "X$AVAIL_RENAMES" = "X" ]; then
-	AVAIL_RENAMES="$CONFIG/renames"
-fi
-
-# Find the Java virtual machine.
-VM=$(command -v java)
-if [ "X$VM" = "X" ]; then
-	echo "Fatal error: Could not locate the Java virtual machine (java)."
-	exit 1
-fi
-
-# The JVM for Mac OS X understands a few options that make for a prettier dock.
-OSNAME=$(uname -s)
-if [ "$OSNAME" = "Darwin" ]; then
-	OSARGS=-Xdock:name=$(basename "$0")\ -Xdock:icon=$AVAIL_HOME/images/AvailHammer.png
-else
-	OSARGS=
-fi
-
-# These are the system arguments for the Java virtual machine.
-VMARGS=-Xmx2g\ -classpath\ "$AVAIL_HOME/lib"\ $OSARGS\ "-Djava.util.logging.config.file=$HOME/.avail/logging.properties"\ "-DavailRoots=$AVAIL_ROOTS"\ "-DavailRenames=$AVAIL_RENAMES"
+source avail-config
 
 # Launch the Avail development environment in the background.
 DEVJAR=$AVAIL_HOME/lib/avail-workbench-1.4-all.jar
 # shellcheck disable=SC2048
 # shellcheck disable=SC2086
-$VM $VMARGS -jar "$DEVJAR" $* &
+$VM "${VMARGS[@]}" -jar "$DEVJAR" $* &

--- a/distro/bin/avail-server
+++ b/distro/bin/avail-server
@@ -31,10 +31,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+JAR=$AVAIL_HOME/lib/avail-server-1.4-all.jar
+
 source avail-config
 
-# Launch the Avail server in the background.
-SERVJAR=$AVAIL_HOME/lib/avail-server-1.4-all.jar
-# shellcheck disable=SC2048
-# shellcheck disable=SC2086
-$VM "${VMARGS[@]}" -jar "$SERVJAR" $* &
+# Launch the Avail server
+if [ "$FORCE_FOREGROUND" = true ]; then
+    $VM "${VMARGS[@]}" -jar $JAR $*
+else
+	$VM "${VMARGS[@]}" -jar $JAR $* &
+fi
+

--- a/distro/bin/avail-server
+++ b/distro/bin/avail-server
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # avail-server
-# Copyright © 1993-2019, The Avail Foundation, LLC.
+# Copyright © 1993-2020, The Avail Foundation, LLC.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,85 +31,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-# Make sure that AVAIL_HOME is set.
-if [ "X$AVAIL_HOME" = "X" ]; then
-	echo "Fatal error: AVAIL_HOME is not set."
-	exit 1
-fi
-
-# Create a configuration directory if necessary. Fix the permissions if it is
-# not readable and writable by the current user.
-AVAIL_USER=$HOME/.avail
-CONFIG=$AVAIL_USER/etc
-if [ ! -e "$CONFIG" ]; then
-	install -d -m 700 "$CONFIG"
-elif [ ! -d "$CONFIG" ]; then
-	echo "Fatal error: $CONFIG exists but is not a directory."
-	exit 1
-elif [ ! -r "$CONFIG" -o ! -w "$CONFIG" ]; then
-	chmod u+rw "$CONFIG"
-fi
-
-# Copy the standard configuration file for logging, but only if the user does
-# not already have one in place.
-if [ ! -e "$CONFIG/logging.properties" ]; then
-	cp "$AVAIL_HOME/etc/logging.properties" "$CONFIG/logging.properties"
-elif [ ! -f "$CONFIG/logging.properties" ]; then
-	echo "Fatal error: $CONFIG/logging.properties exists but is not a regular file"
-	exit 1
-fi
-
-# Create an empty renames file, but only if the user does not already have an
-# existing one.
-if [ ! -e "$CONFIG/renames" ]; then
-	touch "$CONFIG/renames"
-elif [ ! -f "$CONFIG/renames" ]; then
-	echo "Fatal error: $CONFIG/renames exists but it is not a regular file"
-	exit 1
-fi
-
-# Create the repository directory if necessary. Fix the permissions if it is
-# not readable and writable by the current user.
-REPOS=$AVAIL_USER/repos
-if [ ! -e "$REPOS" ]; then
-	install -d -m 700 "$REPOS"
-elif [ ! -d "$REPOS" ]; then
-	echo "Fatal error: $REPOS exists but is not a directory."
-	exit 1
-elif [ ! -r "$REPOS" -o ! -w "$REPOS" ]; then
-	chmod u+rw "$REPOS"
-fi
-
-# If AVAIL_ROOTS is not set, then default it.
-if [ "X$AVAIL_ROOTS" = "X" ]; then
-	AVAIL_ROOTS="avail=$REPOS/avail.repo,$AVAIL_HOME/src/avail"';'"examples=$REPOS/examples.repo,$AVAIL_HOME/src/examples"
-fi
-
-# If AVAIL_RENAMES is not set, then default it.
-if [ "X$AVAIL_RENAMES" = "X" ]; then
-	AVAIL_RENAMES="$CONFIG/renames"
-fi
-
-# Find the Java virtual machine.
-VM=$(command -v java)
-if [ "X$VM" = "X" ]; then
-	echo "Fatal error: Could not locate the Java virtual machine (java)."
-	exit 1
-fi
-
-# The JVM for Mac OS X understands a few options that make for a prettier dock.
-OSNAME=$(uname -s)
-if [ "$OSNAME" = "Darwin" ]; then
-	OSARGS=-Xdock:name=$(basename "$0")\ -Xdock:icon=$AVAIL_HOME/images/AvailHammer.png
-else
-	OSARGS=
-fi
-
-# These are the system arguments for the Java virtual machine.
-VMARGS=-Xmx2g\ -classpath\ "$AVAIL_HOME/lib"\ $OSARGS\ "-Djava.util.logging.config.file=$HOME/.avail/logging.properties"\ "-DavailRoots=$AVAIL_ROOTS"\ "-DavailRenames=$AVAIL_RENAMES"
+source avail-config
 
 # Launch the Avail server in the background.
 SERVJAR=$AVAIL_HOME/lib/avail-server-1.4-all.jar
 # shellcheck disable=SC2048
 # shellcheck disable=SC2086
-$VM $VMARGS -jar "$SERVJAR" $* &
+$VM "${VMARGS[@]}" -jar "$SERVJAR" $* &

--- a/distro/bin/availc
+++ b/distro/bin/availc
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # availc
-# Copyright © 1993-2019, The Avail Foundation, LLC.
+# Copyright © 1993-2020, The Avail Foundation, LLC.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,85 +31,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-# Make sure that AVAIL_HOME is set.
-if [ "X$AVAIL_HOME" = "X" ]; then
-	echo "Fatal error: AVAIL_HOME is not set."
-	exit 1
-fi
-
-# Create a configuration directory if necessary. Fix the permissions if it is
-# not readable and writable by the current user.
-AVAIL_USER=$HOME/.avail
-CONFIG=$AVAIL_USER/etc
-if [ ! -e "$CONFIG" ]; then
-	install -d -m 700 "$CONFIG"
-elif [ ! -d "$CONFIG" ]; then
-	echo "Fatal error: $CONFIG exists but is not a directory."
-	exit 1
-elif [ ! -r "$CONFIG" -o ! -w "$CONFIG" ]; then
-	chmod u+rw "$CONFIG"
-fi
-
-# Copy the standard configuration file for logging, but only if the user does
-# not already have one in place.
-if [ ! -e "$CONFIG/logging.properties" ]; then
-	cp "$AVAIL_HOME/etc/logging.properties" "$CONFIG/logging.properties"
-elif [ ! -f "$CONFIG/logging.properties" ]; then
-	echo "Fatal error: $CONFIG/logging.properties exists but is not a regular file"
-	exit 1
-fi
-
-# Create an empty renames file, but only if the user does not already have an
-# existing one.
-if [ ! -e "$CONFIG/renames" ]; then
-	touch "$CONFIG/renames"
-elif [ ! -f "$CONFIG/renames" ]; then
-	echo "Fatal error: $CONFIG/renames exists but it is not a regular file"
-	exit 1
-fi
-
-# Create the repository directory if necessary. Fix the permissions if it is
-# not readable and writable by the current user.
-REPOS=$AVAIL_USER/repos
-if [ ! -e "$REPOS" ]; then
-	install -d -m 700 "$REPOS"
-elif [ ! -d "$REPOS" ]; then
-	echo "Fatal error: $REPOS exists but is not a directory."
-	exit 1
-elif [ ! -r "$REPOS" -o ! -w "$REPOS" ]; then
-	chmod u+rw "$REPOS"
-fi
-
-# If AVAIL_ROOTS is not set, then default it.
-if [ "X$AVAIL_ROOTS" = "X" ]; then
-	AVAIL_ROOTS="avail=$REPOS/avail.repo,$AVAIL_HOME/src/avail"';'"examples=$REPOS/examples.repo,$AVAIL_HOME/src/examples"
-fi
-
-# If AVAIL_RENAMES is not set, then default it.
-if [ "X$AVAIL_RENAMES" = "X" ]; then
-	AVAIL_RENAMES="$CONFIG/renames"
-fi
-
-# Find the Java virtual machine.
-VM=$(command -v java)
-if [ "X$VM" = "X" ]; then
-	echo "Fatal error: Could not locate the Java virtual machine (java)."
-	exit 1
-fi
-
-# The JVM for Mac OS X understands a few options that make for a prettier dock.
-OSNAME=$(uname -s)
-if [ "$OSNAME" = "Darwin" ]; then
-	OSARGS=-Xdock:name=$(basename "$0")\ -Xdock:icon=$AVAIL_HOME/images/AvailHammer.png
-else
-	OSARGS=
-fi
-
-# These are the system arguments for the Java virtual machine.
-VMARGS=-Xmx2g\ -classpath\ "$AVAIL_HOME/lib"\ $OSARGS\ "-Djava.util.logging.config.file=$HOME/.avail/logging.properties"\ "-DavailRoots=$AVAIL_ROOTS"\ "-DavailRenames=$AVAIL_RENAMES"
+source avail-config
 
 # Launch the Avail development environment in the background.
 CLIJAR=$AVAIL_HOME/lib/avail-cli-1.4-all.jar
 # shellcheck disable=SC2048
 # shellcheck disable=SC2086
-$VM $VMARGS -jar "$CLIJAR" $*
+$VM "${VMARGS[@]}" -jar "$CLIJAR" $*

--- a/distro/bin/availc
+++ b/distro/bin/availc
@@ -33,6 +33,7 @@
 
 JAR=$AVAIL_HOME/lib/avail-cli-1.4-all.jar
 
+SKIP_OPT=true
 source avail-config
 
 # Launch the Avail shell environment

--- a/distro/bin/availc
+++ b/distro/bin/availc
@@ -31,10 +31,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+JAR=$AVAIL_HOME/lib/avail-cli-1.4-all.jar
+
 source avail-config
 
-# Launch the Avail development environment in the background.
-CLIJAR=$AVAIL_HOME/lib/avail-cli-1.4-all.jar
-# shellcheck disable=SC2048
-# shellcheck disable=SC2086
-$VM "${VMARGS[@]}" -jar "$CLIJAR" $*
+# Launch the Avail shell environment
+$VM "${VMARGS[@]}" -jar "$JAR" $*


### PR DESCRIPTION
- Externalize the common elements of the three bash scripts `availc`, `avail-dev`, and `avail-server` to a single source'd dependency.
- Change invocation of `$AVAIL_ROOTS` to better support paths containing spaces, which did not work at all for me
- Add a small assortment of parsed flags to the scripts:
  - `-?` for usage help
  - `-a <module_root>` for creating ad-hoc additions to the roots list
  - `-c` for using the current working directory as an improvised module root (under the label _local.$USER.DirectoryName_)
  - `-d` to "dry run" and print the final JVM command rather than executing it
  - `-e` to enable Java assertions
  - `-f` to run the command in the foreground

At present `availc` doesn't use the above flags since it already parses its own (and most of them are either duplicative or irrelevant).