### PR TITLE
Wumpus letters

### DIFF
--- a/distro/src/avail/Avail.avail/Foundation.avail/Characters.avail
+++ b/distro/src/avail/Avail.avail/Foundation.avail/Characters.avail
@@ -1141,7 +1141,7 @@ Public stable method "_is a letter" is
 [
  	c : character
 |
-	c's character type number ∈ {"Lu", "Ll", "Lt", "Lm", "Lo"}
+	c's character category ∈ {"Lu", "Ll", "Lt", "Lm", "Lo"}
 ] : boolean;
 
 /**


### PR DESCRIPTION
Wumpus was broken due to a bug introduced 2020.01.30 (by MvG) in "_is a letter".