### PR TITLE
IndexedFileAnalyzer now supports "--patch-utf-8 <dest>" option.

### DIFF
--- a/avail-cli/src/main/kotlin/com/avail/tools/fileanalyzer/configuration/IndexedFileAnalyzerConfiguration.kt
+++ b/avail-cli/src/main/kotlin/com/avail/tools/fileanalyzer/configuration/IndexedFileAnalyzerConfiguration.kt
@@ -94,4 +94,7 @@ class IndexedFileAnalyzerConfiguration : Configuration
 
 	/** The name of the [IndexedFile] to analyze. */
 	internal var inputFile: File? = null
+
+	/** The destination file if stripping UTF-8 encoding from records. */
+	internal var patchOutputFile: File? = null
 }


### PR DESCRIPTION
- This option strips off a redundant UTF-8 encoding, or fails if such
  a double-encoding is not present.  Metadata is copied verbatim.