### PR TITLE
IndexedFileAnalyzer implode support

### DIFF
--- a/indexed-file-analyzer/src/main/kotlin/com/avail/tools/fileanalyzer/IndexedFileAnalyzer.kt
+++ b/indexed-file-analyzer/src/main/kotlin/com/avail/tools/fileanalyzer/IndexedFileAnalyzer.kt
@@ -48,6 +48,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.system.exitProcess
 import kotlin.text.Charsets.UTF_8
+import kotlin.text.RegexOption.IGNORE_CASE
 
 /**
  * The IndexedFileAnalyzer understands options that are specified in detail in
@@ -119,16 +120,14 @@ object IndexedFileAnalyzer
 		file: File
 	): IndexedFileBuilder(parseHeader(file))
 
-	/**
-	 * Extract the header string from the file with the given name.
-	 */
+	/** Extract the header string from the file with the given name. */
 	fun parseHeader(file: File): String =
 		file.inputStream().reader(UTF_8).buffered().use {
 			buildString {
 				while (true) {
 					val ch = it.read()
-					append(ch.toChar())
 					if (ch == 0) break
+					append(ch.toChar())
 				}
 			}
 		}
@@ -310,11 +309,65 @@ object IndexedFileAnalyzer
 			// and ensure that any supplied paths are syntactically valid.
 			configuration = configure(args)
 			with(configuration) {
+				if (implodeDirectory !== null)
+				{
+					assert(inputFile === null)
+					assert(implodeHeader !== null)
+					assert(implodeOutput !== null)
+					val dir = implodeDirectory!!
+					// The default option file is used as the output.
+					val outputFile = implodeOutput!!
+					if (outputFile.exists())
+					{
+						throw Exception(
+							"Output file must not already exist")
+					}
+					val files = dir.list()!!.toMutableList()
+					val metadata = when
+					{
+						files.remove("metadata") -> "metadata"
+						files.remove("metadata.txt") -> "metadata.txt"
+						else -> null
+					}
+					val regex = "^(\\d+)(\\.txt)?$".toRegex(IGNORE_CASE)
+					files.forEach {
+						if (!regex.matches(it))
+						{
+							throw Exception(
+								"Unexpected file '$it'. Implode directory "
+									+ "entries must be numeric, or numeric + "
+									+ "'.txt', and contiguous, starting at 0. "
+									+ "'metadata' or 'metadata.txt' is also "
+									+ "supported.")
+						}
+					}
+					files.sortBy { regex.replace(it, "$1").toInt() }
+					for (i in files.indices)
+					{
+						val name = files[i]
+						if (regex.replace(name, "$1").toInt() != i)
+						{
+							throw Exception(
+								"Cannot find file '$i' or '$i.txt'.")
+						}
+					}
+					val indexedFileBuilder =
+						object : IndexedFileBuilder(implodeHeader!!) { }
+					val out = indexedFileBuilder.openOrCreate(
+						outputFile, true)
+					files.forEach { out.add(dir.resolve(it).readBytes()) }
+					metadata?.let {
+						out.metadata = dir.resolve(it).readBytes()
+					}
+					out.commit()
+					return
+				}
 				val builder = ArbitraryIndexedFileBuilder(inputFile!!)
 				indexedFile = builder.openOrCreate(inputFile!!, false)
 				val indices = indices()
 				when {
-					patchOutputFile !== null -> {
+					patchOutputFile !== null ->
+					{
 						// Patch the file into an output file by transforming
 						// each record, stripping one level of UTF-8 encoding.
 						// Fail and delete the destination file if any record
@@ -348,7 +401,8 @@ object IndexedFileAnalyzer
 							throw e
 						}
 					}
-					explodeDirectory !== null -> {
+					explodeDirectory !== null ->
+					{
 						// Explode records into files.
 						val dir = explodeDirectory!!
 						val suffix = if (text) ".txt" else ""
@@ -365,14 +419,16 @@ object IndexedFileAnalyzer
 							}
 						}
 					}
-					counts && !binary && !text && !sizes -> {
+					counts && !binary && !text && !sizes ->
+					{
 						// Output a raw count, a linefeed, and nothing else.
 						assert(!metadata)
 						println(indices.count())
 					}
-					counts || sizes || binary || text -> {
+					counts || sizes || binary || text ->
+					{
 						// Output a stream of records.
-						indices().forEach {
+						indices.forEach {
 							writeRecord(it, System.out)
 						}
 						if (metadata) writeRecord(-1L, System.out)

--- a/indexed-file-analyzer/src/main/kotlin/com/avail/tools/fileanalyzer/configuration/IndexedFileAnalyzerConfiguration.kt
+++ b/indexed-file-analyzer/src/main/kotlin/com/avail/tools/fileanalyzer/configuration/IndexedFileAnalyzerConfiguration.kt
@@ -82,6 +82,23 @@ class IndexedFileAnalyzerConfiguration : Configuration
 	internal var explodeDirectory: File? = null
 
 	/**
+	 * The directory, containing records and optionally metadata, to assemble
+	 * into an indexed file.
+	 */
+	internal var implodeDirectory: File? = null
+
+	/**
+	 * The header string that indicates the kind of [IndexedFile] to create.
+	 * Must be present iff [implodeDirectory] is present.
+	 */
+	internal var implodeHeader: String? = null
+
+	/**
+	 * The output [File] for an implosion from some [implodeDirectory].
+	 */
+	internal var implodeOutput: File? = null
+
+	/**
 	 * `true` iff metadata should be processed as well.  `false` by default.
 	 */
 	internal var metadata = false

--- a/src/main/kotlin/com/avail/persistence/IndexedFileBuilder.kt
+++ b/src/main/kotlin/com/avail/persistence/IndexedFileBuilder.kt
@@ -42,22 +42,22 @@ import java.io.RandomAccessFile
  * @constructor
  * @param headerString
  *   The [String] to check for at the start of a file implementing this kind of
- *   specialization of an [IndexedFile].
- * @return
- *   An array of bytes that uniquely identifies the purpose of the indexed
- *   file.
+ *   specialization of an [IndexedFile].  Note that the terminating NUL byte is
+ *   *NOT* expected to be part of the string supplied by the client (as of
+ *   2020.10.21).
  *
  * @author Todd L Smith &lt;todd@availlang.org&gt;
  * @author Mark van Gulik &lt;mark@availlang.org&gt;
  * @author Skatje Myers &lt;skatje.myers@gmail.com&gt;
  */
-abstract class IndexedFileBuilder protected constructor(headerString: String)
+abstract class IndexedFileBuilder constructor(headerString: String)
 {
 	/**
 	 * The NUL-terminated header bytes that uniquely identify a particular usage
-	 * of the core [IndexedFile] technology.
+	 * of the core [IndexedFile] technology.  The NUL byte is added here, and
+	 * should not be supplied by the constructor.
 	 */
-	val headerBytes = headerString.toByteArray(Charsets.UTF_8)
+	val headerBytes = headerString.toByteArray(Charsets.UTF_8) + ByteArray(1)
 
 	/**
 	 * The default page size of the [IndexedFile]. This should be a multiple of

--- a/src/main/kotlin/com/avail/persistence/Repository.kt
+++ b/src/main/kotlin/com/avail/persistence/Repository.kt
@@ -96,7 +96,7 @@ class Repository constructor(
 	 * @author Mark van Gulik &lt;mark@availlang.org&gt;
 	 */
 	private object IndexedRepositoryBuilder : IndexedFileBuilder(
-		"Avail compiled module repository\u0000")
+		"Avail compiled module repository")
 
 	/**
 	 * The [lock][ReentrantLock] responsible for guarding against unsafe


### PR DESCRIPTION
IndexedFileAnalyzer now supports file creation.  It expects the
implode-directory to contain files named 0 or 0.txt, 1 or 1.txt,
etc., plus optional metadata or metadata.txt.  The implode-header
indicates the header string, and therefore indexed file type to
create.  The implode-output specifies a new output file.
- IndexFileBuilder now expects the specified header string *NOT*
  to contain the terminating null character.  The file format is
  the same, but the protocol has changed.
- NOTE: There are some failing unrelated tests related to large
  changes that Rich is still in the process of making.