### PR TITLE
Minor stuff with repository concurrency and `analyze` script.

### DIFF
--- a/avail-core/src/main/kotlin/com/avail/persistence/cache/Repository.kt
+++ b/avail-core/src/main/kotlin/com/avail/persistence/cache/Repository.kt
@@ -69,13 +69,15 @@ import java.util.logging.Logger
 import kotlin.concurrent.withLock
 
 /**
- * An `Repository` manages a persistent [IndexedFile] of compiled
+ * A [Repository] manages a persistent [IndexedFile] of compiled
  * [modules][ModuleDescriptor].
  *
+ * ```
  * **Metadata:**
- *  1. #modules
- *  2. For each module,
+ * 1. #modules
+ * 2. For each module,
  *    2a. moduleArchive
+ *
  * **ModuleArchive:**
  * 1. UTF8 rootRelativeName
  * 2. digestCache size
@@ -86,9 +88,11 @@ import kotlin.concurrent.withLock
  * 5. For each version,
  *    5a. ModuleVersionKey
  *    5b. ModuleVersion
+ *
  * **ModuleVersionKey:**
  * 1. isPackage (byte)
  * 2. digest (32 bytes)
+ *
  * **ModuleVersion:**
  * 1. moduleSize (long)
  * 2. localImportNames size (int)
@@ -103,14 +107,17 @@ import kotlin.concurrent.withLock
  *    7b. ModuleCompilation
  * 8. moduleHeaderRecordNumber (long)
  * 9. stacksRecordNumber (long)
+ *
  * **ModuleCompilationKey:**
  * 1. predecessorCompilationTimes length (int)
  * 2. For each predecessor compilation time,
  *    2a. predecessor compilation time (long)
+ *
  * **ModuleCompilation:**
  * 1. compilationTime (long)
  * 2. recordNumber (long)
  * 3. recordNumberOfBlockPhrases (long)
+ * ```
  *
  * @property rootName
  *   The name of the [Avail&#32;root][ModuleRoot] represented by this
@@ -207,7 +214,7 @@ class Repository constructor(
 	 */
 	class LimitedCache<K, V> constructor(
 		private val maximumSize: Int)
-	: LinkedHashMap<K, V>(maximumSize,0.75f,true)
+	: LinkedHashMap<K, V>(maximumSize, 0.75f, true)
 	{
 		init
 		{
@@ -424,10 +431,6 @@ class Repository constructor(
 		 */
 		fun putVersion(versionKey: ModuleVersionKey, version: ModuleVersion) =
 			lock.withLock {
-				assert(!versions.containsKey(versionKey)) {
-					"A version for $rootRelativeName has already been added " +
-						"for this ModuleVersionKey"
-				}
 				versions[versionKey] = version
 				markDirty()
 			}
@@ -453,7 +456,6 @@ class Repository constructor(
 				compilation: ModuleCompilation) =
 			lock.withLock {
 				val version = versions[versionKey]!!
-				assert(version.getCompilation(compilationKey) === null)
 				version.compilations[compilationKey] = compilation
 				markDirty()
 			}

--- a/distro/bin/analyze
+++ b/distro/bin/analyze
@@ -34,7 +34,7 @@
 # Assume the currently installed Java is adequate to run the
 # IndexedFileAnalyzer.
 
-JAR=$AVAIL_HOME/lib/indexed-file-analyzer-all.jar
+JAR=$AVAIL_HOME/lib/indexed-file-analyzer.jar
 
 FORCE_FOREGROUND=true
 SKIP_OPT=true

--- a/distro/bin/avail-config
+++ b/distro/bin/avail-config
@@ -71,7 +71,7 @@ fi
 
 # Create the repository directory if necessary. Fix the permissions if it is
 # not readable and writable by the current user.
-REPO_DIR=$AVAIL_USER/repos
+REPO_DIR=$AVAIL_USER/repositories
 if [ ! -e "$REPO_DIR" ]; then
   install -d -m 700 "$REPO_DIR"
 elif [ ! -d "$REPO_DIR" ]; then
@@ -103,7 +103,7 @@ else
       improvised_name="${improvised_name%%.*}"
       improvised_name="local.$USER.${improvised_name// /}"
       # the root's name is given as local.username.directoryname
-      ADDITIONAL_ROOTS+=("$improvised_name=$REPO_DIR/$improvised_name.repo,$PWD")
+      ADDITIONAL_ROOTS+=("$improvised_name=$PWD")
       ;;
     d)
       # perform a [d]ry run and output the final command instead of running it
@@ -161,9 +161,9 @@ fi
 
 # If AVAIL_ROOTS is not set, then default it.
 if [ "X$AVAIL_ROOTS" = "X" ]; then
-  AVAIL_ROOTS="avail=$REPO_DIR/avail.repo,$AVAIL_HOME/src/avail"
+  AVAIL_ROOTS="avail=$AVAIL_HOME/src/avail"
   if [ "$USE_EXAMPLE_ROOTS" = true ]; then
-    AVAIL_ROOTS="$AVAIL_ROOTS"';'"examples=$REPO_DIR/examples.repo,$AVAIL_HOME/src/examples"
+    AVAIL_ROOTS="$AVAIL_ROOTS"';'"examples=$AVAIL_HOME/src/examples"
   fi
 fi
 


### PR DESCRIPTION
Removed too-strong assertions about repository state that no longer hold
in the presence of multi-process shared access.
- Updated `analyze` script (and `avail-config`) for changes like
  removing repo name from roots format, and renamed jars.