### PR TITLE
Temporary scaffolding to print the atom / module name that is Cmd-clicked.

### DIFF
--- a/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
+++ b/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
@@ -153,6 +153,7 @@ import avail.io.TextInterface
 import avail.performance.Statistic
 import avail.performance.StatisticReport.WORKBENCH_TRANSCRIPT
 import avail.persistence.cache.Repositories
+import avail.persistence.cache.record.NameInModule
 import avail.resolver.ModuleRootResolver
 import avail.resolver.ResolverReference
 import avail.stacks.StacksGenerator
@@ -2595,6 +2596,17 @@ class AvailWorkbench internal constructor(
 		availProject.availProjectRoots.firstOrNull {
 			it.name == targetRootName
 		}
+
+	/**
+	 * The user has clicked on a token in the source in such a way that they are
+	 * requesting navigation related to the method name containing that token.
+	 */
+	fun navigateForName(nameInModule: NameInModule)
+	{
+		//TODO present a list of definitions and usages to navigate to.
+		println(
+			"Clicked on ${nameInModule.atomName} in ${nameInModule.moduleName}")
+	}
 
 	companion object
 	{

--- a/avail/src/main/kotlin/avail/anvil/text/CodePane.kt
+++ b/avail/src/main/kotlin/avail/anvil/text/CodePane.kt
@@ -45,6 +45,8 @@ import java.awt.Dimension
 import java.awt.Font
 import java.awt.Toolkit.getDefaultToolkit
 import java.awt.event.ActionEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import javax.swing.BorderFactory
 import javax.swing.InputMap
 import javax.swing.JTextPane
@@ -104,6 +106,8 @@ class CodePane constructor(
 	internal val undoManager = UndoManager().apply {
 		limit = if (isEditable) 1000 else 1
 	}
+
+	internal var clickHandler: (e: MouseEvent) -> Unit = {}
 
 	/**
 	 * The state of an ongoing template selection.
@@ -180,6 +184,11 @@ class CodePane constructor(
 			putClientProperty(CodePane::undoManager.name, undoManager)
 			putClientProperty(CodePane::currentEdit.name, currentEdit)
 		}
+		addMouseListener(
+			object : MouseAdapter()
+			{
+				override fun mouseClicked(e: MouseEvent) = clickHandler(e)
+			})
 	}
 
 	/**


### PR DESCRIPTION
The goal of this review is for the reviewer to gain some familiarity with the relevant indexing structures.
Where the AvailWorkbench currently prints the text about the clicked name, it should present a dialog box or menu showing all definitions and usages of the name across the entire project.
As a next step, we might just load and decode the NamesIndex information associated with each module recursively contained within the module roots.  Then we can start populating the Bloom filters in the NamesIndex records for package representatives, and use them to avoid having to scan inside each file – unless the filter says the name (probably) occurs inside some submodule.