### PR TITLE
Fixed index calculation bugs that were splitting double-struck

### DIFF
--- a/avail-artifact/src/main/kotlin/org/availlang/artifact/AvailArtifactBuildPlan.kt
+++ b/avail-artifact/src/main/kotlin/org/availlang/artifact/AvailArtifactBuildPlan.kt
@@ -27,7 +27,7 @@ import java.util.zip.ZipFile
  * otherwise.
  *
  * @author Richard Arriaga
- * 
+ *
  * @property version
  *   The version to give to the created artifact. **REQUIRED**
  * @property outputLocation
@@ -305,7 +305,8 @@ class AvailArtifactBuildPlan private constructor(
 					projectFileName, projectPath)}/$ARTIFACT_PLANS_FILE"
 			).readText()) {}.map {
 				AvailArtifactBuildPlan(
-					projectPath, it as JSONObject)
+					projectDirectory = projectPath,
+					obj = it as JSONObject)
 			}.toMutableList()
 	}
 }

--- a/avail/.avail/examples-avail-config/artifact-plans.json
+++ b/avail/.avail/examples-avail-config/artifact-plans.json
@@ -1,1 +1,26 @@
-[]
+[
+    {
+        "version": "2.0.0.alpha19-1.6.1.alpha08",
+        "artifactType": "LIBRARY",
+        "outputLocation":
+        {
+            "locationType": "project",
+            "scheme": "JAR",
+            "path": "avail-stdlib/build/libs/z/avail-stdlib-2.0.0.alpha20-1.6.1.alpha09.jar"
+        },
+        "implementationTitle" : "Avail Standard Library",
+        "jvmComponent": {
+            "hasJVMComponents": false,
+            "description": "",
+            "mains": []
+        },
+        "jarMainClass": "",
+        "artifactDescription": "The Avail Standard Library primary module root",
+        "rootNames": ["avail"],
+        "includedFiles": [],
+        "jarFileLocations": [],
+        "zipFileLocations": [],
+        "directoryLocations": [],
+        "customManifestItems": {}
+    }
+]

--- a/avail/.idea/dictionaries/markvangulik.xml
+++ b/avail/.idea/dictionaries/markvangulik.xml
@@ -12,6 +12,7 @@
       <w>bgcolor</w>
       <w>boundedly</w>
       <w>calendrical</w>
+      <w>canonicalize</w>
       <w>canonicalized</w>
       <w>canonicity</w>
       <w>cardinalities</w>

--- a/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
+++ b/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
@@ -158,6 +158,7 @@ import avail.descriptor.fiber.FiberDescriptor
 import avail.descriptor.module.A_Module
 import avail.descriptor.module.ModuleDescriptor
 import avail.descriptor.phrases.A_Phrase
+import avail.descriptor.tuples.A_String.SurrogateIndexConverter
 import avail.descriptor.tuples.StringDescriptor.Companion.stringFrom
 import avail.descriptor.tuples.TupleDescriptor.Companion.quoteStringOn
 import avail.files.FileManager
@@ -3104,11 +3105,11 @@ class AvailWorkbench internal constructor(
 										}
 									}
 									val spansStart =
-										spans.minOfOrNull { it.start } ?: 1
+										spans.minOfOrNull { it.start } ?: 0
 									val spansPastEnd =
-										spans.maxOfOrNull { it.pastEnd } ?: 1
+										spans.maxOfOrNull { it.pastEnd } ?: 0
 									editor.sourcePane
-										.select(spansStart - 1, spansPastEnd - 1)
+										.select(spansStart, spansPastEnd)
 									editor.sourcePane
 										.showTextRange(spansStart, spansPastEnd)
 								}
@@ -3158,17 +3159,24 @@ class AvailWorkbench internal constructor(
 		val indexMap = mutableMapOf<Int, Int>()
 		val quoteBuilder = StringBuilder()
 		quoteBuilder.quoteStringOn(availName, indexMap)
+		val quoted = quoteBuilder.toString()
+		// We have the mapping from the availName into the quoted String, so
+		// now get a second mapping back into the quoted Avail string.
+		val converter = SurrogateIndexConverter(quoted)
 		val originalRange = MessageSplitter.split(availName)
 			.rangeToHighlightForPartIndex(tokenIndexInName)
-		val startOfRange = indexMap[originalRange.first]!! + 1
-		val pastEndOfRange = indexMap[originalRange.last + 1]!! + 1
-		val quoted = quoteBuilder.toString()
+		val startOfRangeInString = indexMap[originalRange.first]!!
+		val startOfRangeInAvail =
+			converter.javaIndexToAvailIndex(startOfRangeInString) + 1
+		val pastEndOfRangeInString = indexMap[originalRange.last + 1]!!
+		val pastEndOfRangeInAvail =
+			converter.javaIndexToAvailIndex(pastEndOfRangeInString) + 1
 		val styledName = htmlStyledMethodName(
 			stringFrom(quoted),
 			true,
 			stylesheet,
-			startOfRange,
-			pastEndOfRange)
+			startOfRangeInAvail,
+			pastEndOfRangeInAvail)
 		val title = buildString {
 			append("<html><tt><font size='+1'>")
 			append(styledName)

--- a/avail/src/main/kotlin/avail/anvil/SwingHelper.kt
+++ b/avail/src/main/kotlin/avail/anvil/SwingHelper.kt
@@ -393,9 +393,10 @@ inline fun Graphics.antiAliased(draw: Graphics2D.()->Unit) = withHints(
 )
 
 /**
- * Given a range and a [Glow], apply that glow to the characters in that range.
- * Add a highlight for the first character, the middle region if any, and the
- * last character of that range.  A size-one range acts as both a first and last
+ * Given a range and a [Glow], apply that glow to the characters in that range,
+ * which consists of zero-based indices of the start and end inclusive.  Add a
+ * highlight for the first character, the middle region if any, and the last
+ * character of that range.  A size-one range acts as both a first and last
  * character, with no middle part.  This simplifies rendering of a box
  * highlight, since the highlight mechanism is executed for each styled run
  * separately, with no easy way to tell if the left or right walls of the box

--- a/avail/src/main/kotlin/avail/builder/BuildLoader.kt
+++ b/avail/src/main/kotlin/avail/builder/BuildLoader.kt
@@ -696,27 +696,29 @@ internal class BuildLoader constructor(
 	{
 		val loader = context.loader
 		val converter = context.surrogateIndexConverter
+		// Map from 1-based Avail indices to 0-based UTF-16 indices.
 		val styleRanges = loader.lockStyles {
 			map { (start, pastEnd, style) ->
 				val utf16Start =
-					converter.availIndexToJavaIndex(start.toInt())
+					converter.availIndexToJavaIndex(start.toInt() - 1)
 				val utf16PastEnd =
-					converter.availIndexToJavaIndex(pastEnd.toInt())
-				(utf16Start until utf16PastEnd) to style
+					converter.availIndexToJavaIndex(pastEnd.toInt() - 1)
+				(utf16Start .. utf16PastEnd) to style
 			}
 		}
+		assert(styleRanges.all { (range, _) -> range.first < range.last })
 		val uses = loader.lockUsesToDefinitions {
 			map { (useStart, usePastEnd, defRange) ->
 				val utf16UseStart =
-					converter.availIndexToJavaIndex(useStart.toInt())
+					converter.availIndexToJavaIndex(useStart.toInt() - 1)
 				val utf16UsePastEnd =
-					converter.availIndexToJavaIndex(usePastEnd.toInt())
+					converter.availIndexToJavaIndex(usePastEnd.toInt() - 1)
 				val utf16DefStart =
-					converter.availIndexToJavaIndex(defRange.first.toInt())
+					converter.availIndexToJavaIndex(defRange.first.toInt() - 1)
 				val utf16DefEnd =
 					converter.availIndexToJavaIndex(defRange.last.toInt())
 				Pair(
-					(utf16UseStart until utf16UsePastEnd),
+					(utf16UseStart .. utf16UsePastEnd),
 					(utf16DefStart .. utf16DefEnd))
 			}
 		}

--- a/avail/src/main/kotlin/avail/compiler/CompilationContext.kt
+++ b/avail/src/main/kotlin/avail/compiler/CompilationContext.kt
@@ -1403,9 +1403,9 @@ class CompilationContext constructor(
 						(token: A_Token, indexInName: A_Number) ->
 					if (!token.isInCurrentModule(module)) return@mapNotNull null
 					val start = surrogateIndexConverter.availIndexToJavaIndex(
-						token.start())
+						token.start() - 1)
 					val pastEnd = surrogateIndexConverter.availIndexToJavaIndex(
-						token.pastEnd())
+						token.pastEnd() - 1)
 					val line = token.lineNumber()
 					val inName = indexInName.extractInt
 					val string = when (inName)

--- a/avail/src/main/kotlin/avail/descriptor/tuples/A_String.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/A_String.kt
@@ -54,11 +54,11 @@ interface A_String : A_Tuple
 	 */
 	class SurrogateIndexConverter(string: String)
 	{
-		val highSurrogatesInJavaString = string.indices.filter {
+		private val highSurrogatesInJavaString = string.indices.filter {
 			string[it].isHighSurrogate()
 		}.toTypedArray()
 
-		val highCodePointsInAvailString = highSurrogatesInJavaString
+		private val highCodePointsInAvailString = highSurrogatesInJavaString
 			.mapIndexed { arrayPos, javaIndex ->
 				javaIndex - arrayPos
 			}.toTypedArray()

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
@@ -1399,7 +1399,7 @@ protected constructor(
 		 *   The [StringBuilder] on which to write the quoted string.
 		 * @param string
 		 *   The [A_String] to quote.
-		 * @param
+		 * @param map
 		 *   The optional [MutableMap] to populate from one-based positions in
 		 *   the given [string] to corresponding zero-based positions in the
 		 *   builder.

--- a/avail/src/main/kotlin/avail/interpreter/execution/AvailLoader.kt
+++ b/avail/src/main/kotlin/avail/interpreter/execution/AvailLoader.kt
@@ -184,6 +184,7 @@ import avail.descriptor.tokens.A_Token.Companion.end
 import avail.descriptor.tokens.A_Token.Companion.pastEnd
 import avail.descriptor.tuples.A_String
 import avail.descriptor.tuples.A_String.Companion.asNativeString
+import avail.descriptor.tuples.A_String.Companion.copyStringFromToCanDestroy
 import avail.descriptor.tuples.A_Tuple
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleCodePointAt
@@ -2306,9 +2307,10 @@ constructor(
 				{
 					stylesheet[styleString].encloseHtml(this) {
 						// Be sure to escape any special characters like '<'.
-						val substring = native.substring(
-							start.toInt() - 1, pastEnd.toInt() - 1)
-						append(substring.escapedForHTML())
+						val substring: A_String =
+							quotedName.copyStringFromToCanDestroy(
+								start.toInt(), pastEnd.toInt() - 1, false)
+						append(substring.asNativeString().escapedForHTML())
 					}
 				}
 			}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/bootstrap/lexing/P_BootstrapLexerStringBody.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/bootstrap/lexing/P_BootstrapLexerStringBody.kt
@@ -122,10 +122,10 @@ object P_BootstrapLexerStringBody
 		var erasurePosition = 0
 		while (scanner.hasNext())
 		{
-			var c = scanner.next().toChar()
+			var c = scanner.next()
 			when (c)
 			{
-				'\"' ->
+				'\"'.code ->
 				{
 					return literalToken(
 						source.copyStringFromToCanDestroy(
@@ -135,7 +135,7 @@ object P_BootstrapLexerStringBody
 						stringFrom(builder.toString()),
 						lexer)
 				}
-				'\\' ->
+				'\\'.code ->
 				{
 					if (!scanner.hasNext())
 					{
@@ -144,15 +144,15 @@ object P_BootstrapLexerStringBody
 							"more characters after backslash in string " +
 								"literal")
 					}
-					c = scanner.next().toChar()
+					c = scanner.next()
 					when (c)
 					{
-						'n' -> builder.append('\n')
-						'r' -> builder.append('\r')
-						't' -> builder.append('\t')
-						'\\' -> builder.append('\\')
-						'\"' -> builder.append('\"')
-						'\r' ->
+						'n'.code -> builder.append('\n')
+						'r'.code -> builder.append('\r')
+						't'.code -> builder.append('\t')
+						'\\'.code -> builder.append('\\')
+						'\"'.code -> builder.append('\"')
+						'\r'.code ->
 						{
 							// Treat \r or \r\n in the source just like \n.
 							if (scanner.hasNext()
@@ -162,18 +162,18 @@ object P_BootstrapLexerStringBody
 							}
 							canErase = true
 						}
-						'\u000C', '\n', // '\u000C' == '\f'
+						'\u000C'.code, '\n'.code, // '\u000C' == '\f'
 							// NEL (Next Line)
-						'\u0085',
+						'\u0085'.code,
 							// LS (Line Separator)
-						'\u2028',
+						'\u2028'.code,
 							// PS (Paragraph Separator)
-						'\u2029' ->
+						'\u2029'.code ->
 							// A backslash ending a line.  Emit nothing.
 							// Allow '\|' to back up to here as long as only
 							// whitespace follows.
 							canErase = true
-						'|' ->
+						'|'.code ->
 							// Remove all immediately preceding white space
 							// from this line.
 							if (canErase)
@@ -188,8 +188,8 @@ object P_BootstrapLexerStringBody
 									"only whitespace characters on line "
 										+ "before \"\\|\" ")
 							}
-						'(' -> parseUnicodeEscapes(scanner, builder)
-						'[' -> throw AvailRejectedParseException(
+						'('.code -> parseUnicodeEscapes(scanner, builder)
+						'['.code -> throw AvailRejectedParseException(
 							WEAK,
 							"something other than \"\\[\", because power "
 								+ "strings are not yet supported")
@@ -202,7 +202,7 @@ object P_BootstrapLexerStringBody
 					}
 					erasurePosition = builder.length
 				}
-				'\r' ->
+				'\r'.code ->
 				{
 					// *Transform* \r or \r\n in the source into \n.
 					if (scanner.hasNext() && scanner.peek() == '\n'.code)
@@ -213,17 +213,17 @@ object P_BootstrapLexerStringBody
 					canErase = true
 					erasurePosition = builder.length
 				}
-				'\n' ->
+				'\n'.code ->
 				{
 					// Just like a regular character, but limit how much
 					// can be removed by a subsequent '\|'.
-					builder.appendCodePoint(c.code)
+					builder.appendCodePoint(c)
 					canErase = true
 					erasurePosition = builder.length
 				}
 				else ->
 				{
-					builder.appendCodePoint(c.code)
+					builder.appendCodePoint(c)
 					if (canErase && !Character.isWhitespace(c))
 					{
 						canErase = false

--- a/avail/src/main/kotlin/avail/persistence/cache/Repository.kt
+++ b/avail/src/main/kotlin/avail/persistence/cache/Repository.kt
@@ -154,7 +154,7 @@ class Repository constructor(
 	 * @author Mark van Gulik &lt;mark@availlang.org&gt;
 	 */
 	private object IndexedRepositoryBuilder : IndexedFileBuilder(
-		"Avail compiled module repository V16")
+		"Avail compiled module repository V17")
 
 	/**
 	 * The [lock][ReentrantLock] responsible for guarding against unsafe

--- a/avail/src/main/kotlin/avail/persistence/cache/record/PhrasePathRecord.kt
+++ b/avail/src/main/kotlin/avail/persistence/cache/record/PhrasePathRecord.kt
@@ -272,16 +272,16 @@ constructor (
 		/**
 		 * An entry in the [tokenSpans] of a PhraseNode.  The [start] and
 		 * [pastEnd] identify where the token occurs in the UCS-2 source
-		 * [String], but using one-based indices.  The [tokenIndexInName] is
+		 * [String], using zero-based indices.  The [tokenIndexInName] is
 		 * either zero or a one-based index into the atom's [MessageSplitter]'s
 		 * [MessageSplitter.messageParts], indicating the part of the message
 		 * that this token matched during parsing.
 		 *
 		 * @property start
-		 *   The one-based index into the UCS-2 [String] at which the token
+		 *   The zero-based index into the UCS-2 [String] at which the token
 		 *   begins.
 		 * @property pastEnd
-		 *   The one-based index into the UCS-2 [String] just past the token.
+		 *   The zero-based index into the UCS-2 [String] just past the token.
 		 * @property line
 		 *   The one-based line number containing the token.  If the token spans
 		 *   multiple lines (say a string literal), this is the line number of

--- a/avail/src/main/kotlin/avail/persistence/cache/record/StylingRecord.kt
+++ b/avail/src/main/kotlin/avail/persistence/cache/record/StylingRecord.kt
@@ -84,8 +84,7 @@ class StylingRecord
 		binaryStream.vlq(styleToIndex.size)
 		stylesList.forEach(binaryStream::sizedString)
 		var pos = 0
-		// Collect the <style#, length> pairs, dropping any zero-length
-		// spans.
+		// Collect the <style#, length> pairs, dropping any zero-length spans.
 		val nonemptyRuns = mutableListOf<Pair<Int, Int>>()
 		styleRuns.forEach { (run, styleName) ->
 			val delta = run.first - pos
@@ -95,10 +94,10 @@ class StylingRecord
 				// Output an unstyled span.
 				nonemptyRuns.add(0 to delta)
 			}
-			assert (run.last >= run.first)
+			assert (run.last > run.first)
 			nonemptyRuns.add(
-				styleToIndex[styleName]!! to run.last - run.first + 1)
-			pos = run.last + 1
+				styleToIndex[styleName]!! to run.last - run.first)
+			pos = run.last
 		}
 		// Output contiguous styled (and unstyled) spans.
 		binaryStream.vlq(nonemptyRuns.size)
@@ -196,8 +195,7 @@ class StylingRecord
 			if (styleNumber > 0)
 			{
 				allRuns.add(
-					(pos - length until pos)
-						to styles[styleNumber - 1])
+					(pos - length .. pos) to styles[styleNumber - 1])
 			}
 		}
 		styleRuns = allRuns
@@ -244,10 +242,12 @@ class StylingRecord
 	 *
 	 * @param styleRuns
 	 *   An ascending sequence of non-overlapping, non-empty [IntRange]s, with
-	 *   the style name to apply to that range.
+	 *   the style name to apply to that range.  The ranges are
+	 *   `start .. pastEnd` in zero-based numbering within the UTF-16 Java
+	 *   string.
 	 * @param variableUses
 	 *   Information about variable uses and definitions.  The pairs go from use
-	 *   to definition.
+	 *   to definition.  The [IntRange]s are as for [styleRuns].
 	*/
 	constructor(
 		styleRuns: List<StyleRun>,


### PR DESCRIPTION
W (𝕎) into its constituent UTF-16 surrogates in the editor. It was also being mis-parsed when it occurred in a string literal (issue #277).
- Incremented repo version to V17.
- Avail artifacts now exclude ".DS_Store" automatically (issue #255).