### PR TITLE
Postload blocks and other things

### DIFF
--- a/avail/.idea/dictionaries/markvangulik.xml
+++ b/avail/.idea/dictionaries/markvangulik.xml
@@ -30,6 +30,7 @@
       <w>deemphasize</w>
       <w>deoptimize</w>
       <w>deoptimized</w>
+      <w>dest</w>
       <w>devirtualize</w>
       <w>dfff</w>
       <w>distro</w>

--- a/avail/.idea/encodings.xml
+++ b/avail/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8" />
+</project>

--- a/avail/.idea/inspectionProfiles/Project_Default.xml
+++ b/avail/.idea/inspectionProfiles/Project_Default.xml
@@ -399,7 +399,7 @@
       <option name="m_allowConstructorAsInitializer" value="true" />
       <option name="m_onlyLookAtBlocks" value="false" />
     </inspection_tool>
-    <inspection_tool class="TrailingSpacesInProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TrailingSpacesInProperty" enabled="true" level="WARNING" enabled_by_default="true" ignoreVisibleSpaces="true" />
     <inspection_tool class="TryStatementWithMultipleResources" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeParameterExtendsFinalClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UNUSED_IMPORT" enabled="true" level="ERROR" enabled_by_default="true" />

--- a/avail/.idea/runConfigurations/Avail_Project_Manager.xml
+++ b/avail/.idea/runConfigurations/Avail_Project_Manager.xml
@@ -1,5 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Avail Project Manager" type="JetRunConfigurationType">
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="avail.project.AvailProjectManagerRunner" />
     <module name="avail.main" />
     <shortenClasspath name="NONE" />

--- a/avail/build.gradle.kts
+++ b/avail/build.gradle.kts
@@ -120,6 +120,43 @@ val formattedNow: String get()
 val isReleaseVersion =
 	!version.toString().toUpperCaseAsciiOnly().endsWith("SNAPSHOT")
 
+/** The root Avail distribution directory name. */
+val distroDir = "distro"
+
+/** The relative path to the Avail distribution source directory. */
+val distroSrc = systemPath(distroDir, "src")
+
+/** The relative path to the Avail distribution lib directory. */
+val distroLib = systemPath(distroDir, "lib")
+
+/** The path to the bootstrap package. */
+val bootstrapPackagePath =
+	systemPath("avail", "tools", "bootstrap")
+
+/**
+ * The [Project.getProjectDir] relative path of the bootstrap package.
+ */
+val relativePathBootstrap =
+	systemPath("src", "main", "kotlin", bootstrapPackagePath)
+
+/**
+ * [Project.getProjectDir]-relative path to the generated JVM classes.
+ */
+val buildClassesPath = "classes/kotlin/main"
+
+/**
+ * The build time string of the form: "yyyy-MM-ddTHH:mm:ss.SSSZ",
+ * representing the time of the build.
+ */
+val built: String get() = formattedNow
+
+/**
+ * The [Project.getProjectDir] relative path of the built bootstrap package.
+ */
+val relativePathBootstrapClasses =
+	systemPath(buildClassesPath, bootstrapPackagePath)
+
+
 java {
 	toolchain {
 		languageVersion.set(JavaLanguageVersion.of(jvmTarget))
@@ -533,12 +570,6 @@ abstract class GenerateFileManifestTask: DefaultTask()
 	}
 }
 
-/** The root Avail distribution directory name. */
-val distroDir = "distro"
-
-/** The relative path to the Avail distribution source directory. */
-val distroSrc = systemPath(distroDir, "src")
-
 /**
  * Answer an [AvailRoot] relative to this [Project.getProjectDir].
  *
@@ -576,37 +607,11 @@ fun Project.computeAvailRootsForTest (): String =
  *   The constructed String path.
  */
 fun systemPath(vararg path: String): String =
-	path.toList().joinToString(File.separator)
-
-/** The relative path to the Avail distribution lib directory. */
-val distroLib = systemPath(distroDir, "lib")
-
-/** The path to the bootstrap package. */
-val bootstrapPackagePath =
-	systemPath("avail", "tools", "bootstrap")
-
-/**
- * The [Project.getProjectDir] relative path of the bootstrap package.
- */
-val relativePathBootstrap =
-	systemPath("src", "main", "kotlin", bootstrapPackagePath)
-
-/**
- * [Project.getProjectDir]-relative path to the generated JVM classes.
- */
-val buildClassesPath = "classes/kotlin/main"
-
-/**
- * The build time string of the form: "yyyy-MM-ddTHH:mm:ss.SSSZ",
- * representing the time of the build.
- */
-val built: String get() = formattedNow
-
-/**
- * The [Project.getProjectDir] relative path of the built bootstrap package.
- */
-val relativePathBootstrapClasses =
-	systemPath(buildClassesPath, bootstrapPackagePath)
+	path.toList().joinToString(File.separator) { s ->
+		@Suppress("RedundantRequireNotNullCall")
+		checkNotNull(s)
+		s
+	}
 
 /**
  * `Avail` Root represents an Avail source root.
@@ -679,7 +684,7 @@ fun Project.projectGenerateBootStrap(task: Copy)
 	task.inputs.files + pathBootstrap
 	val distroBootstrap =
 		file(systemPath(
-			"${rootProject.projectDir}",
+			"$projectDir",
 			distroSrc,
 			"avail",
 			"Avail.avail",

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Bootstrap.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Bootstrap.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Error Codes.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Error Codes.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Fallible Primitives.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Fallible Primitives.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */
@@ -50,6 +50,7 @@ Uses
 	(
 		"$_@pc=_stack=_[_]caller=_",
 		"Abstract method_is_",
+		"After the current module is loaded,⁇do_",
 		"After the current module is unloaded,⁇do_",
 		"Alias_to_",
 		"Attempt to join_",
@@ -519,14 +520,14 @@ Primitive "_→function" is
  * @method "$_@pc=_stack=_[_]caller=_"
  * @param "aFunction" "[…]→⊤"
  *        The new continuation's current function.
- * @param "programCounter" "[0..∞)"
+ * @param "programCounter" "𝕎"
  *        @param "aFunction"'s program counter. This is the index of the
  *        next Level One instruction to execute when the new continuation is
  *        resumed.
  * @param "stack" "tuple"
  *        @param "aFunction"'s stack. This tuple contains the arguments, local
  *        variables, and temporaries.
- * @param "stackPointer" "[1..∞)"
+ * @param "stackPointer" "ℕ"
  *        @param "aFunction"'s stack pointer. This is the index of the
  *        top of the stack.
  * @param "caller" "↑$[…]→⊥"
@@ -643,7 +644,7 @@ Primitive "Restart_with_" is
  * @method "_→extended integer"
  * @param "aDouble" "double"
  *        A double-precision floating point number.
- * @returns "[-∞..∞]"
+ * @returns "ℤ∞"
  *    The requested value.
  * @raises "cannot-convert-not-a-number-to-integer exception"
  */
@@ -722,7 +723,7 @@ Primitive "new⁇heritable«fiber-local»⁇atom named_" is
  *        A function.
  * @param "arguments" "tuple"
  *        The arguments to the function.
- * @param "priority" "[0..255]"
+ * @param "priority" "u8"
  *        The priority of the new fiber.
  * @returns "fiber→⊤"
  *    The new fiber.
@@ -757,7 +758,7 @@ Primitive "in_millisecond|milliseconds,⁇invoke_with_,⁇forked at priority_" i
  *        A function.
  * @param "arguments" "tuple"
  *        The arguments to the function.
- * @param "priority" "[0..255]"
+ * @param "priority" "u8"
  *        The priority of the new fiber.
  * @returns "⊤"
  * @raises "incorrect-number-of-arguments exception"
@@ -811,7 +812,7 @@ Primitive "_'s⁇result" is
  *        A function.
  * @param "arguments" "tuple"
  *        The arguments to the function.
- * @param "priority" "[0..255]"
+ * @param "priority" "u8"
  *        The priority of the new fiber.
  * @returns "fiber→⊤"
  *    The new fiber.
@@ -840,7 +841,7 @@ Primitive "invoke_with_,⁇forked at priority_" is
  *        A function.
  * @param "arguments" "tuple"
  *        The arguments to the function.
- * @param "priority" "[0..255]"
+ * @param "priority" "u8"
  *        The priority of the new fiber.
  * @returns "⊤"
  * @raises "incorrect-number-of-arguments exception"
@@ -934,7 +935,7 @@ Primitive "Remove current fiber[_]" is
  * @method "_→extended integer"
  * @param "aFloat" "float"
  *        A single-precision floating point number.
- * @returns "[-∞..∞]"
+ * @returns "ℤ∞"
  *    The requested value.
  * @raises "cannot-convert-not-a-number-to-integer exception"
  */
@@ -976,11 +977,11 @@ Primitive "function from_and_" is
  *
  * @category "Primitives" "Types" "Functions" "Queries"
  * @method "_[_]"
- * @param "functionType" "([…]→⊤)'s type"
+ * @param "functionType" "{[…]→⊤}ᵀ"
  *        A function type.
- * @param "index" "[1..∞)"
+ * @param "index" "ℕ"
  *        The one-based index of the desired parameter type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The {@param "index"}-th parameter type of the argument.
  * @raises "subscript-out-of-bounds exception"
  */
@@ -1000,7 +1001,7 @@ Primitive "_[_]" is
  *
  * @category "Primitives" "Standard IO"
  * @method "Mark for_character|characters of read ahead"
- * @param "count" "[0..∞)"
+ * @param "count" "𝕎"
  *        The requested number of characters of read ahead.
  * @returns "⊤"
  * @raises "I/O exception"
@@ -1090,11 +1091,11 @@ Primitive "Reset to mark" is
  *
  * @category "Primitives" "Numbers" "Integers" "Mathematics" "Bits"
  * @method "_<<_"
- * @param "baseInteger" "(-∞..∞)"
+ * @param "baseInteger" "ℤ"
  *        An integer to shift.
- * @param "shiftFactor" "(-∞..∞)"
+ * @param "shiftFactor" "ℤ"
  *        How many bits to shift left (or right if negative).
- * @returns "(-∞..∞)"
+ * @returns "ℤ"
  *    ⌊_<<_ × 2<sup>baseInteger</sup>⌋
  * @raises "too-large-to-represent exception"
  */
@@ -1115,11 +1116,11 @@ Primitive "_<<_" is
  *
  * @category "Primitives" "Numbers" "Integers" "Mathematics" "Bits"
  * @method "_>>_"
- * @param "baseInteger" "(-∞..∞)"
+ * @param "baseInteger" "ℤ"
  *        An integer to shift.
- * @param "shiftFactor" "(-∞..∞)"
+ * @param "shiftFactor" "ℤ"
  *        How many bits to shift right (or left if negative).
- * @returns "(-∞..∞)"
+ * @returns "ℤ"
  *    ⌊_>>_ ÷ 2<sup>baseInteger</sup>⌋
  * @raises "too-large-to-represent exception"
  */
@@ -1140,14 +1141,14 @@ Primitive "_>>_" is
  *
  * @category "Primitives" "Numbers" "Integers" "Mathematics" "Bits"
  * @method "_<<_keeping_bits"
- * @param "baseInteger" "[0..∞)"
+ * @param "baseInteger" "𝕎"
  *        A non-negative integer to shift and mask.
- * @param "shiftFactor" "(-∞..∞)"
+ * @param "shiftFactor" "ℤ"
  *        How many bit positions to shift left by (negative for a right shift).
- * @param "truncationBits" "[0..∞)"
+ * @param "truncationBits" "𝕎"
  *        The number of low-order bits to preserve after the shift (must
  *        be ≥ 0).
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    ⌊_<<_keeping_bits × 2<sup>baseInteger</sup>⌋ mod 2<sup>shiftFactor</sup>
  * @raises "too-large-to-represent exception"
  */
@@ -1167,17 +1168,18 @@ Primitive "_<<_keeping_bits" is
  *
  * @category "Primitives"
  * @method "internal link_"
- * @param "source" "<character…|1..∞>"
+ * @param "source" "character+"
  *        The root-relative fully qualified name of the source file to link.
  *        This is the resource jar file that contains the primitives.
  * @returns "permission-denied exception"
  *        The set of missing primitive classes from the jar file, if any.
- * @raises "{<character…|1..∞>|}"
+ * @raises "{character+|}"
  * @raises "I/O exception"
  * @raises "permission-denied exception"
  * @raises "cannot-define-during-compilation exception"
  * @raises "loading-is-over exception"
  * @raises "no-file exception"
+ * @raises "invalid-path exception"
  */
 Primitive "internal link_" is
 [
@@ -1227,12 +1229,12 @@ Primitive "_[_]" is
  * @method "_«[_]»[_.._]→_"
  * @param "aMap" "map"
  *        The target map.
- * @param "pathTuple" "<any…|1..∞>"
+ * @param "pathTuple" "any+"
  *        The tuple providing the path to follow to reach the location
  *        to be updated.
- * @param "sliceStartIndex" "[1..∞)"
+ * @param "sliceStartIndex" "ℕ"
  *        The start index of the tuple slice to be replaced.
- * @param "sliceEndIndex" "[0..∞)"
+ * @param "sliceEndIndex" "𝕎"
  *        The end index of the tuple slice to be replaced.
  * @param "newValues" "tuple"
  *        The tuple containing the replacement values.
@@ -1269,7 +1271,7 @@ Primitive "_«[_]»[_.._]→_" is
  * @method "_«[_]»→_"
  * @param "aMap" "map"
  *        The target map.
- * @param "pathTuple" "<any…|1..∞>"
+ * @param "pathTuple" "any+"
  *        The tuple providing the path to follow to reach the location
  *        to be updated.
  * @param "newValue" "any"
@@ -1309,7 +1311,7 @@ Primitive "_«[_]»→_" is
  * @method "Abstract method_is_"
  * @param "methodName" "string"
  *        The name of the abstract method to declare.
- * @param "aFunctionType" "([…]→⊤)'s type"
+ * @param "aFunctionType" "{[…]→⊤}ᵀ"
  *        The signature.
  * @returns "⊤"
  * @raises "incorrect-argument-type exception"
@@ -1384,7 +1386,7 @@ Primitive "Abstract method_is_" is
  * @method "Abstract method_is_"
  * @param "methodName" "atom"
  *        The atom that uniquely names the abstract method to declare.
- * @param "signature" "([…]→⊤)'s type"
+ * @param "signature" "{[…]→⊤}ᵀ"
  *        The signature.
  * @returns "⊤"
  * @raises "incorrect-argument-type exception"
@@ -1463,7 +1465,7 @@ Primitive "Abstract method_is_" is
  * @method "Semantic restriction_is_"
  * @param "methodName" "string"
  *        The name of the method to which the semantic restriction applies.
- * @param "restriction" "[…]→(⊤)'s type"
+ * @param "restriction" "[…]→{⊤}ᵀ"
  *        The restriction function.
  * @returns "⊤"
  * @raises "incorrect-number-of-arguments exception"
@@ -1542,7 +1544,7 @@ Primitive "Semantic restriction_is_" is
  * @method "Semantic restriction_is_"
  * @param "methodName" "atom"
  *        The name of the method to which the semantic restriction applies.
- * @param "restriction" "[…]→(⊤)'s type"
+ * @param "restriction" "[…]→{⊤}ᵀ"
  *        The restriction function.
  * @returns "⊤"
  * @raises "incorrect-number-of-arguments exception"
@@ -1678,7 +1680,7 @@ Primitive "Alias_to_" is
  * @method "_has definition for_"
  * @param "methodName" "atom"
  *        A method name (an atom).
- * @param "parameterTypes" "<(any)'s type…|>"
+ * @param "parameterTypes" "{any}ᵀ*"
  *        A tuple of parameter types. This must agree in length with the number
  *        of parameters expected by the method.
  * @returns "boolean"
@@ -1781,7 +1783,7 @@ Primitive "Copy macros from_to_" is
  * @method "method definition of_for_"
  * @param "methodName" "atom"
  *        The name of the method.
- * @param "parameterTypes" "<(any)'s type…|>"
+ * @param "parameterTypes" "{any}ᵀ*"
  *        A tuple of parameter types. This must agree in length with the number
  *        of parameters expected by the method.
  * @returns "definition"
@@ -1817,7 +1819,7 @@ Primitive "method definition of_for_" is
  * @method "Forward method_is_"
  * @param "methodName" "string"
  *        The name of the method to forward declare.
- * @param "aFunctionType" "([…]→⊤)'s type"
+ * @param "aFunctionType" "{[…]→⊤}ᵀ"
  *        The signature.
  * @returns "⊤"
  * @raises "incorrect-argument-type exception"
@@ -1897,7 +1899,7 @@ Primitive "Forward method_is_" is
  * @method "Grammatical restriction_is_"
  * @param "methodsToRestrict" "{string|1..∞}"
  *        A set of method names, each of which should be restricted.
- * @param "exclusions" "<{string|}…|>"
+ * @param "exclusions" "{string|}*"
  *        A tuple of sets of method names. The method names in the `n`-th set
  *        are restricted from occurring grammatically at the `n`-th argument
  *        position of any invocation of a method named in
@@ -1976,7 +1978,7 @@ Primitive "Grammatical restriction_is_" is
  * @method "Grammatical restriction_is_"
  * @param "methodsToRestrict" "{atom|1..∞}"
  *        A set of method names, each of which should be restricted.
- * @param "exclusions" "<{atom|}…|>"
+ * @param "exclusions" "{atom|}*"
  *        A tuple of sets of method names. The method names in the
  *       `n`-th set are restricted from occurring grammatically at the `n`-th
  *       argument position of any invocation of a method named in
@@ -2157,7 +2159,7 @@ Primitive "message_contains groups" is
  * @method "`|message_'s⁇parameters`|"
  * @param "methodName" "string"
  *        A method name.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The number of parameters required to send the specified message.
  * @raises "incorrect-argument-type exception"
  * @raises "incorrect-type-for-group exception"
@@ -2215,7 +2217,7 @@ Primitive "`|message_'s⁇parameters`|" is
  * @method "Seal method_at_"
  * @param "methodName" "string"
  *        The name of the method to seal.
- * @param "signature" "<(any)'s type…|>"
+ * @param "signature" "{any}ᵀ*"
  *        A tuple of parameter types. This is the signature at which the
  *       seal will be placed.
  * @returns "⊤"
@@ -2284,7 +2286,7 @@ Primitive "Seal method_at_" is
  * @method "Seal method_at_"
  * @param "methodName" "atom"
  *        The atom that uniquely designates the method to seal.
- * @param "signature" "<(any)'s type…|>"
+ * @param "signature" "{any}ᵀ*"
  *        A tuple of parameter types. This is the signature at which the seal
  *        will be placed.
  * @returns "⊤"
@@ -2372,10 +2374,10 @@ Primitive "Seal method|methods_at existing definitions" is
  * @method "semantic restrictions for_given_"
  * @param "aMethod" "method"
  *        A method.
- * @param "arguments" "<(any)'s type…|>"
+ * @param "arguments" "{any}ᵀ*"
  *        The tuple of arguments that should be used to filter the semantic
  *        restrictions.
- * @returns "<[…]→(⊤)'s type…|>"
+ * @returns "[…]→{⊤}ᵀ*"
  *    The requested semantic restrictions.
  * @raises "incorrect-number-of-arguments exception"
  */
@@ -2403,9 +2405,9 @@ Primitive "semantic restrictions for_given_" is
  *        The atom that names the lexer.
  * @param "filterFunction" "[character]→boolean"
  *        The filter function of the lexer.
- * @param "bodyFunction" "[string, [1..∞), [1..∞)]→{<token…|1..∞>|}"
+ * @param "bodyFunction" "[string, ℕ, ℕ]→{token+|}"
  *        The body of the lexer.
- * @param "optionalStyler" "<[<send phrase⇒⊤…|0..1>, phrase⇒⊤]→⊤…|0..1>"
+ * @param "optionalStyler" "[send phrase⇒⊤?, phrase⇒⊤]→⊤?"
  *        The optional function used for styling invocations of this lexer.
  * @raises "⊤"
  * @raises "incorrect-argument-type exception"
@@ -2484,11 +2486,11 @@ Primitive "Lexer_when_is_«styled by_»?" is
  * @method "Macro_is«_,»_«styled by_»?"
  * @param "macroName" "string"
  *        The name of the macro to define.
- * @param "prefixFunctions" "<[…]→⊤…|>"
+ * @param "prefixFunctions" "[…]→⊤*"
  *        A tuple of zero or more prefix functions.
  * @param "body" "[…]→phrase⇒⊤"
  *        The function that implements the macro.
- * @param "optionalStyler" "<[<send phrase⇒⊤…|0..1>, phrase⇒⊤]→⊤…|0..1>"
+ * @param "optionalStyler" "[send phrase⇒⊤?, phrase⇒⊤]→⊤?"
  *        The optional function used for styling invocations of this macro.
  * @returns "⊤"
  * @raises "incorrect-number-of-arguments exception"
@@ -2585,11 +2587,11 @@ Primitive "Macro_is«_,»_«styled by_»?" is
  * @method "Macro_is«_,»_«styled by_»?"
  * @param "macroName" "atom"
  *        The name of the macro to define.
- * @param "prefixFunctions" "<[…]→⊤…|>"
+ * @param "prefixFunctions" "[…]→⊤*"
  *        A tuple of zero or more prefix functions.
  * @param "body" "[…]→phrase⇒⊤"
  *        The function that implements the macro.
- * @param "optionalStyler" "<[<send phrase⇒⊤…|0..1>, phrase⇒⊤]→⊤…|0..1>"
+ * @param "optionalStyler" "[send phrase⇒⊤?, phrase⇒⊤]→⊤?"
  *        The optional function used for styling invocations of this macro.
  * @returns "⊤"
  * @raises "incorrect-number-of-arguments exception"
@@ -2664,6 +2666,26 @@ Primitive "Macro_is«_,»_«styled by_»?" is
 
 /**
  * Register the given function for callback after the module undergoing
+ * compilation has been otherwise fully parsed and compiled.
+ *
+ * @category "Primitives"
+ * @method "After the current module is loaded,⁇do_"
+ * @param "aFunction" "[…]→⊤"
+ *        The post-load function.
+ * @returns "⊤"
+ * @raises "loading-is-over exception"
+ */
+Primitive "After the current module is loaded,⁇do_" is
+[
+	aFunction : function
+|
+	Primitive AddPostLoadFunction (failureCode : {
+		loading-is-over code}ᵀ);
+	Private invoke _fail_primitive with failureCode
+] : ⊤;
+
+/**
+ * Register the given function for callback after the module undergoing
  * compilation has been unloaded.
  *
  * @category "Primitives" "Modules" "Mutators"
@@ -2709,7 +2731,7 @@ Primitive "Close module_" is
  *
  * @category "Primitives" "Modules"
  * @method "new anonymous module importing_"
- * @param "allImports" "<<string, <<<<boolean, <character…|1..∞>, <<character…|1..∞>…|0..1>…|3>…|>, boolean…|2>…|0..1>…|2>…|1..∞>"
+ * @param "allImports" "<string, <<boolean, character+, character+?…|3>*, boolean…|2>?…|2>+"
  *        Every module and name to be imported privately by the new module.
  * @returns "module"
  *    The new module.
@@ -2949,11 +2971,11 @@ Primitive "_[_]" is
  *
  * @category "Primitives" "Types" "Objects" "Queries"
  * @method "_[_]"
- * @param "objectType" "(object)'s type"
+ * @param "objectType" "{object}ᵀ"
  *        An object type.
  * @param "field" "atom"
  *        The field for which to extract the type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The field's constraining type.
  * @raises "no-such-field exception"
  */
@@ -2972,10 +2994,10 @@ Primitive "_[_]" is
  *
  * @category "Primitives" "Types" "Objects" "Maps" "Conversions"
  * @method "_→map"
- * @param "anObjectType" "(object)'s type"
+ * @param "anObjectType" "{object}ᵀ"
  *        An object type whose fields should be the keys of the new map and
  *        whose values are the corresponding values.
- * @returns "{atom→(any)'s type|}"
+ * @returns "{atom→{any}ᵀ|}"
  *    The requested map.
  * @raises "no-such-field exception"
  */
@@ -2993,9 +3015,9 @@ Primitive "_→map" is
  *
  * @category "Primitives" "Types" "Tuples" "Objects" "Conversions"
  * @method "_→tuple"
- * @param "anObjectType" "(object)'s type"
+ * @param "anObjectType" "{object}ᵀ"
  *        An object type.
- * @returns "<<atom, (any)'s type…|2>…|>"
+ * @returns "<atom, {any}ᵀ…|2>*"
  *    A tuple that represents the composition of the object type. Its elements
  *    are 2-tuples. Each 2-tuple's first element is an atom (i.e., the field
  *    identifier) and its second element is the value type permitted by the
@@ -3071,14 +3093,14 @@ Primitive "`«_:=_`»" is
  *
  * @category "Primitives" "Phrases" "Constructors"
  * @method "`«[_`|Primitive__]:_^_`»"
- * @param "argumentDeclarations" "<argument phrase⇒⊤…|>"
+ * @param "argumentDeclarations" "argument phrase⇒⊤*"
  *        A tuple of argument declarations.
  * @param "primitiveName" "string"
  *        The primitive linkage number, or 0 for no primitive linkage.
- * @param "statements" "<phrase⇒⊤…|>"
+ * @param "statements" "phrase⇒⊤*"
  *        A tuple of statements. Each element except for the last must be an
  *        assignment, declaration, label, sequence, or ⊤-valued send.
- * @param "returnType" "(⊤)'s type"
+ * @param "returnType" "{⊤}ᵀ"
  *        The return type.
  * @param "exceptions" "{exception|}"
  *        The set of exceptions that may be raised.
@@ -3107,7 +3129,7 @@ Primitive "`«[_`|Primitive__]:_^_`»" is
  *
  * @category "Primitives"
  * @method "first-of-seq`«_`»"
- * @param "statements" "<phrase⇒⊤…|>"
+ * @param "statements" "phrase⇒⊤*"
  *        A tuple of statements.
  * @returns "first of sequence phrase⇒⊤"
  *    The requested first-of-sequence phrase.
@@ -3131,13 +3153,13 @@ Primitive "first-of-seq`«_`»" is
  *        The value of the literal.
  * @param "lexeme" "string"
  *        The source text of the literal.
- * @param "start" "[0..∞)"
+ * @param "start" "𝕎"
  *        The one-based starting character position of the literal. A {@code 0}
  *        indicates that the character position is unknown or meaningless.
- * @param "line" "[0..∞)"
+ * @param "line" "𝕎"
  *        The one-based line number of the literal. A {@code 0}
  *        indicates that the line number is unknown or meaningless.
- * @param "optionalGeneratingPhrase" "<phrase⇒⊤…|0..1>"
+ * @param "optionalGeneratingPhrase" "phrase⇒⊤?"
  *        The optional phrase from which this token is considered to have been
  *        constructed.
  * @returns "literal token⇒any"
@@ -3164,13 +3186,13 @@ Primitive "``_``(_)@_:_«from phrase_»?" is
  *
  * @category "Primitives"
  * @method "_permuted by_"
- * @param "list" "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @param "list" "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *        The {@type "list phrase"} whose subexpressions should be permuted.
- * @param "permutation" "<[1..∞)…|1..∞>"
+ * @param "permutation" "ℕ+"
  *        The permutation imposed by the resultant {@type
  *        "permuted list phrase"}. This is a {@type "tuple"} of target indices,
  *        index by source index.
- * @returns "permuted list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @returns "permuted list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *    The requested {@type "permuted list phrase"}.
  * @raises "inconsistent-argument-reordering exception"
  */
@@ -3222,13 +3244,13 @@ Primitive "`«`↑_`»" is
  * @method "restricted report and send_with_:_"
  * @param "message" "atom"
  *        The atom that names the method to be invoked by the send phrase.
- * @param "args" "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @param "args" "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *        The list phrase of phrases that are supplied as arguments of the send
  *        phrase.
- * @param "basicReturnType" "(⊤)'s type"
+ * @param "basicReturnType" "{⊤}ᵀ"
  *        The return type of the send phrase, prior to strengthening by
  *        applicable method definitions and semantic restrictions.
- * @returns "<<send phrase⇒⊤…|0..1>, string…|2>"
+ * @returns "<send phrase⇒⊤?, string…|2>"
  *        A pair of the optional restricted send phrase and report string.
  * @raises "incorrect-number-of-arguments exception"
  * @raises "incorrect-argument-type exception"
@@ -3294,10 +3316,10 @@ Primitive "restricted report and send_with_:_" is
  * @method "send_with_:_"
  * @param "messageName" "atom"
  *        The name of the method to be invoked.
- * @param "argumentsList" "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @param "argumentsList" "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *        The list phrase containing the argument expressions, corresponding
  *        left-to-right with the arguments of the method.
- * @param "returnType" "(⊤)'s type"
+ * @param "returnType" "{⊤}ᵀ"
  *        The expected (strengthened) return type of the method send.
  * @returns "send phrase⇒⊤"
  *    The requested message send.
@@ -3357,7 +3379,7 @@ Primitive "send_with_:_" is
  *
  * @category "Primitives" "Phrases" "Constructors"
  * @method "seq`«_`»"
- * @param "statements" "<phrase⇒⊤…|>"
+ * @param "statements" "phrase⇒⊤*"
  *        A tuple of statements.
  * @returns "sequence phrase⇒⊤"
  *    The requested sequence.
@@ -3379,7 +3401,7 @@ Primitive "seq`«_`»" is
  * @method "`«supercast(_::_)`»"
  * @param "baseExpression" "expression phrase⇒any"
  *        The base phrase that produces the argument to be passed in a call.
- * @param "lookupType" "(any)'s type"
+ * @param "lookupType" "{any}ᵀ"
  *        The type to use to lookup this argument rather than its actual type.
  * @returns "super cast phrase⇒any"
  *    A supercast phrase.
@@ -3411,10 +3433,10 @@ Primitive "`«supercast(_::_)`»" is
  *        {@type "token"}.
  * @param "lexeme" "string"
  *        The source text of the {@type "token"}.
- * @param "start" "[0..∞)"
+ * @param "start" "𝕎"
  *        The one-based character position within the Avail source module, or
  *        {@code "0"} if the character position is unknown or meaningless.
- * @param "line" "[0..∞)"
+ * @param "line" "𝕎"
  *        The one-based line number within the Avail source module, or {@code
  *        "0"} if the line number is unknown or meaningless.
  * @returns "token"
@@ -3465,7 +3487,7 @@ Primitive "_'s⁇initializing expression" is
  * @method "lookup macro_with phrases_"
  * @param "macro" "atom"
  *        The atom naming the macro.
- * @param "phrases" "<phrase⇒⊤…|>"
+ * @param "phrases" "phrase⇒⊤*"
  *        The tuple of phrases to use as arguments for the lookup.
  * @returns "[…]→phrase⇒⊤"
  *    The body function of the looked up macro.
@@ -3518,7 +3540,7 @@ Primitive "_'s⁇_field" is
  *
  * @category "Primitives" "Variables" "POJO" "Constructors"
  * @method "_'s⁇_field"
- * @param "aPojoType" "(any)'s type"
+ * @param "aPojoType" "{any}ᵀ"
  *        A pojo type whose static field should be bound to the answered
  *        variable.
  * @param "fieldName" "string"
@@ -3570,9 +3592,9 @@ Primitive "_'s⁇_field" is
  *
  * @category "Primitives" "Functions" "POJO" "Constructors"
  * @method "constructor of_,⁇parameterized by_"
- * @param "aPojoType" "(any)'s type"
+ * @param "aPojoType" "{any}ᵀ"
  *        A pojo type.
- * @param "parameterTypes" "<(any)'s type…|>"
+ * @param "parameterTypes" "{any}ᵀ*"
  *        The parameter types accepted by the desired constructor.
  * @returns "[…]→any"
  *    The requested constructor invocation function.
@@ -3624,11 +3646,11 @@ Primitive "constructor of_,⁇parameterized by_" is
  *
  * @category "Primitives" "Functions" "POJO" "Constructors"
  * @method "method_._,⁇parameterized by_"
- * @param "aPojoType" "(any)'s type"
+ * @param "aPojoType" "{any}ᵀ"
  *        A pojo type.
  * @param "methodName" "string"
  *        The name of the desired method.
- * @param "parameterTypes" "<(any)'s type…|>"
+ * @param "parameterTypes" "{any}ᵀ*"
  *        The parameter types accepted by the desired method.
  * @returns "[…]→⊤"
  *    The requested instance method invocation function.
@@ -3678,11 +3700,11 @@ Primitive "method_._,⁇parameterized by_" is
  *
  * @category "Primitives" "Functions" "POJO" "Constructors"
  * @method "static method_._,⁇parameterized by_"
- * @param "aPojoType" "(any)'s type"
+ * @param "aPojoType" "{any}ᵀ"
  *        A pojo type.
  * @param "methodName" "string"
  *        The name of the desired method.
- * @param "parameterTypes" "<(any)'s type…|>"
+ * @param "parameterTypes" "{any}ᵀ*"
  *        The parameter types accepted by the desired method.
  * @returns "[…]→⊤"
  *    The requested static method invocation function.
@@ -3708,10 +3730,10 @@ Primitive "static method_._,⁇parameterized by_" is
  * @method "_parameterized by_"
  * @param "javaName" "string"
  *        The fully qualified name of the Java class or interface.
- * @param "typeParameters" "<(any)'s type…|>"
+ * @param "typeParameters" "{any}ᵀ*"
  *        The type arguments. The cardinality of this tuple must agree with the
  *        number of type parameters required by the Java class or interface.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The requested pojo type.
  * @raises "incorrect-number-of-arguments exception"
  * @raises "Java-class-not-available exception"
@@ -3734,7 +3756,7 @@ Primitive "_parameterized by_" is
  * @method "_[_]"
  * @param "anArray" "any[]"
  *        A pojo array.
- * @param "index" "[1..∞)"
+ * @param "index" "ℕ"
  *        A one-based index into the pojo array.
  * @returns "any"
  *    The {@param "index"}-th element of {@param "anArray"}.
@@ -3760,7 +3782,7 @@ Primitive "_[_]" is
  * @method "_[_]:=_"
  * @param "anArray" "any[]"
  *        A pojo array.
- * @param "index" "[1..∞)"
+ * @param "index" "ℕ"
  *        A one-based index into the pojo array.
  * @param "value" "any"
  *        The value that should be written into the pojo array.
@@ -3795,7 +3817,7 @@ Primitive "_[_]:=_" is
  * @method "Style_with_"
  * @param "anAtom" "atom"
  *        The bundle for which invocations should be styled.
- * @param "aFunction" "[<send phrase⇒⊤…|0..1>, phrase⇒⊤]→⊤"
+ * @param "aFunction" "[send phrase⇒⊤?, phrase⇒⊤]→⊤"
  *        The function that applies the styling.
  * @returns "⊤"
  * @raises "incorrect-argument-type exception"
@@ -3960,9 +3982,9 @@ Primitive "Style token_as_«overwriting»?" is
  * @method "_[_.._]"
  * @param "aTuple" "tuple"
  *        A tuple.
- * @param "sliceStart" "[1..∞)"
+ * @param "sliceStart" "ℕ"
  *        The one-based start index (inclusive) of the desired slice.
- * @param "sliceEnd" "[0..∞)"
+ * @param "sliceEnd" "𝕎"
  *        The one-based end index (inclusive) of the desired slice.
  * @returns "tuple"
  *    The requested tuple.
@@ -3984,15 +4006,15 @@ Primitive "_[_.._]" is
  *
  * @category "Primitives" "Tuples" "Constructors"
  * @method "_to_by_"
- * @param "start" "(-∞..∞)"
+ * @param "start" "ℤ"
  *        The first value in the tuple.
- * @param "end" "(-∞..∞)"
+ * @param "end" "ℤ"
  *        The last allowed value in the tuple. This value will only be the
  *        last value in the tuple if the difference between the first and last
  *        values is a multiple of the step size.
- * @param "delta" "(-∞..∞)"
+ * @param "delta" "ℤ"
  *        The step size of the interval, which must not be zero.
- * @returns "<(-∞..∞)…|>"
+ * @returns "ℤ*"
  *    The requested tuple.
  * @raises "incorrect-argument-type exception"
  *    If {@param "delta"} is zero.
@@ -4013,7 +4035,7 @@ Primitive "_to_by_" is
  *
  * @category "Primitives" "Tuples" "Constructors"
  * @method "_occurrences⁇of_"
- * @param "count" "[0..∞)"
+ * @param "count" "𝕎"
  *        The number of elements in the resulting tuple.
  * @param "value" "any"
  *        The repeated value.
@@ -4038,7 +4060,7 @@ Primitive "_occurrences⁇of_" is
  * @method "_[_]"
  * @param "aTuple" "tuple"
  *        A tuple.
- * @param "index" "[1..∞)"
+ * @param "index" "ℕ"
  *        The one-based index of the desired element.
  * @returns "any"
  *    The requested element.
@@ -4062,7 +4084,7 @@ Primitive "_[_]" is
  * @method "_[_]→_"
  * @param "aTuple" "tuple"
  *        A tuple.
- * @param "index" "[1..∞)"
+ * @param "index" "ℕ"
  *        The one-based index of the element that should (potentially) differ
  *        in the resultant tuple.
  * @param "value" "any"
@@ -4092,7 +4114,7 @@ Primitive "_[_]→_" is
  * @method "_«[_]»→_"
  * @param "aTuple" "tuple"
  *        The target tuple.
- * @param "pathTuple" "<any…|2..∞>"
+ * @param "pathTuple" "any^[2..∞)"
  *        The tuple providing the path to follow to reach the location
  *        to be updated.
  * @param "newValue" "any"
@@ -4132,11 +4154,11 @@ Primitive "_«[_]»→_" is
  * @method "_[_.._]→_"
  * @param "aTuple" "tuple"
  *        The basis tuple.
- * @param "startIndex" "[1..∞)"
+ * @param "startIndex" "ℕ"
  *        The inclusive start of the range to replace.  This may be as high as
  *        the tuple's size plus one, to indicate the replacement should be
  *        appended.
- * @param "endIndex" "[0..∞)"
+ * @param "endIndex" "𝕎"
  *        The inclusive end of the range to replace.  This may be as low as one
  *        less than the start.
  * @param "replacementSubtuple" "tuple"
@@ -4173,12 +4195,12 @@ Primitive "_[_.._]→_" is
  * @method "_«[_]»[_.._]→_"
  * @param "aTuple" "tuple"
  *        The target tuple.
- * @param "pathTuple" "<any…|1..∞>"
+ * @param "pathTuple" "any+"
  *        The tuple providing the path to follow to reach the location
  *        to be updated.
- * @param "sliceStartIndex" "[1..∞)"
+ * @param "sliceStartIndex" "ℕ"
  *        The start index of the tuple slice to be replaced.
- * @param "sliceEndIndex" "[0..∞)"
+ * @param "sliceEndIndex" "𝕎"
  *        The end index of the tuple slice to be replaced.
  * @param "newValues" "tuple"
  *        The tuple containing the replacement values.
@@ -4213,9 +4235,9 @@ Primitive "_«[_]»[_.._]→_" is
  * @method "_[_↔_]"
  * @param "aTuple" "tuple"
  *        The initial tuple.
- * @param "index1" "[1..∞)"
+ * @param "index1" "ℕ"
  *        An index into the tuple.
- * @param "index2" "[1..∞)"
+ * @param "index2" "ℕ"
  *        Another index into the tuple.
  * @returns "tuple"
  *    A tuple like the input, but with the specified indices swapped.
@@ -4238,13 +4260,13 @@ Primitive "_[_↔_]" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "_[_.._]"
- * @param "aTupleType" "(tuple)'s type"
+ * @param "aTupleType" "{tuple}ᵀ"
  *        A tuple type.
- * @param "sliceStart" "[1..∞)"
+ * @param "sliceStart" "ℕ"
  *        The one-based index (inclusive) of the start of the slice.
- * @param "sliceEnd" "[0..∞)"
+ * @param "sliceEnd" "𝕎"
  *        The one-based index (inclusive) of the end of the slice.
- * @returns "<(any)'s type…|>"
+ * @returns "{any}ᵀ*"
  *    The requested slice of element types.
  * @raises "subscript-out-of-bounds exception"
  * @raises "negative-size exception"
@@ -4266,7 +4288,7 @@ Primitive "_[_.._]" is
  *
  * @category "Primitives" "Types" "Queries"
  * @method "_'s⁇instances"
- * @param "enum" "(⊤)'s type"
+ * @param "enum" "{⊤}ᵀ"
  *        An enumeration.
  * @returns "set"
  *    A set whose members are the instances of the enumeration.
@@ -4340,7 +4362,7 @@ Primitive "_-=_" is
  *
  * @category "Primitives" "Variables" "Constructors"
  * @method "new`↑_initialized to_"
- * @param "containmentType" "(any)'s type"
+ * @param "containmentType" "{any}ᵀ"
  *        The containment type.
  * @param "initialValue" "any"
  *        The initial value to write into the new variable.

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Infallible Primitives.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Infallible Primitives.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */
@@ -379,7 +379,7 @@ Primitive "_'s⁇function" is
  * @method "_'s⁇program counter"
  * @param "aContinuation" "$[…]→⊥"
  *        A continuation.
- * @returns "[1..∞)"
+ * @returns "ℕ"
  *    The argument's Level One program counter.
  */
 Primitive "_'s⁇program counter" is
@@ -420,7 +420,7 @@ Primitive "_'s⁇stack" is
  * @method "_'s⁇stack pointer"
  * @param "aContinuation" "$[…]→⊥"
  *        A continuation.
- * @returns "[1..∞)"
+ * @returns "ℕ"
  *    The argument's stack pointer.
  */
 Primitive "_'s⁇stack pointer" is
@@ -435,9 +435,9 @@ Primitive "_'s⁇stack pointer" is
  *
  * @category "Primitives" "Types" "Continuations" "Queries"
  * @method "_'s⁇function type"
- * @param "continuationType" "($[…]→⊥)'s type"
+ * @param "continuationType" "{$[…]→⊥}ᵀ"
  *        A continuation type.
- * @returns "([…]→⊤)'s type"
+ * @returns "{[…]→⊤}ᵀ"
  *    The argument's current function's type.
  */
 Primitive "_'s⁇function type" is
@@ -453,9 +453,9 @@ Primitive "_'s⁇function type" is
  *
  * @category "Primitives" "Types" "Continuations" "Constructors"
  * @method "$_"
- * @param "functionType" "([…]→⊤)'s type"
+ * @param "functionType" "{[…]→⊤}ᵀ"
  *        A function type.
- * @returns "($[…]→⊥)'s type"
+ * @returns "{$[…]→⊥}ᵀ"
  *    The requested continuation type.
  */
 Primitive "$_" is
@@ -551,7 +551,7 @@ Primitive "⌈_⌉" is
  *
  * @category "Primitives" "Numbers" "Mathematics"
  * @method "_^_"
- * @param "eulerNumber" "(2.718281828459045)'s type"
+ * @param "eulerNumber" "{2.718281828459045}ᵀ"
  *        Euler's number.
  * @param "x" "double"
  *        The exponent.
@@ -592,7 +592,7 @@ Primitive "⌊_⌋" is
  *
  * @category "Primitives" "Numbers" "Mathematics"
  * @method "_reinterpreted as double"
- * @param "anInt64" "[-9223372036854775808..9223372036854775807]"
+ * @param "anInt64" "i64"
  *        A 64-bit signed integer.
  * @returns "double"
  *    The double having the specified bit representation.
@@ -645,8 +645,8 @@ Primitive "_mod_" is
 
 /**
  * Compute and answer an approximation of sin {@param "theta"}, i.e. the
- * ratio of the altitude to the distance between the origin and a point projected at
- * an angle given by the argument in radians.
+ * ratio of the altitude to the distance between the origin and a point projected
+ * at an angle given by the argument in radians.
  *
  * @category "Primitives"
  * @method "sin_"
@@ -671,9 +671,9 @@ Primitive "sin_" is
  * @method "_⨉_^_"
  * @param "a" "double"
  *        A single-precision floating point number.
- * @param "two" "(2)'s type"
+ * @param "two" "{2}ᵀ"
  *        The number two (`2`).
- * @param "b" "(-∞..∞)"
+ * @param "b" "ℤ"
  *        The scaling factor.
  * @returns "double"
  *    The requested value.
@@ -695,7 +695,7 @@ Primitive "_⨉_^_" is
  * @method "_reinterpreted as bits"
  * @param "aDouble" "double"
  *        The double to reinterpret.
- * @returns "[-9223372036854775808..9223372036854775807]"
+ * @returns "i64"
  *    The double's bit representation as a signed 64-bit integer.
  */
 Primitive "_reinterpreted as bits" is
@@ -724,9 +724,9 @@ Primitive "current fiber can reject a parse" is
  *
  * @category "Primitives" "Types" "Concurrency"
  * @method "fiber→_"
- * @param "resultType" "(⊤)'s type"
+ * @param "resultType" "{⊤}ᵀ"
  *        A type.
- * @returns "(fiber→⊤)'s type"
+ * @returns "{fiber→⊤}ᵀ"
  *    The requested fiber type.
  */
 Primitive "fiber→_" is
@@ -771,9 +771,9 @@ Primitive "_'s⁇name" is
  *
  * @category "Primitives" "Types" "Concurrency" "Queries"
  * @method "_'s⁇result type"
- * @param "fiberType" "(fiber→⊤)'s type"
+ * @param "fiberType" "{fiber→⊤}ᵀ"
  *        A fiber type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The argument's result type.
  */
 Primitive "_'s⁇result type" is
@@ -791,7 +791,7 @@ Primitive "_'s⁇result type" is
  * @method "_'s⁇priority"
  * @param "aFiber" "fiber→⊤"
  *        The fiber from which to extract the priority.
- * @returns "[0..255]"
+ * @returns "u8"
  *    A whole number representing the priority of the fiber.
  */
 Primitive "_'s⁇priority" is
@@ -914,7 +914,7 @@ Primitive "_'s⁇name:=_" is
  * @method "_'s⁇priority:=_"
  * @param "aFiber" "fiber→⊤"
  *        The fiber to prioritize.
- * @param "priority" "[0..255]"
+ * @param "priority" "u8"
  *        The new priority.
  * @returns "⊤"
  */
@@ -1056,7 +1056,7 @@ Primitive "⌈_⌉" is
  *
  * @category "Primitives" "Numbers" "Mathematics"
  * @method "_^_"
- * @param "eulerNumber" "(2.718281828459045)'s type"
+ * @param "eulerNumber" "{2.718281828459045}ᵀ"
  *        Euler's number.
  * @param "x" "float"
  *        The exponent.
@@ -1096,7 +1096,7 @@ Primitive "⌊_⌋" is
  *
  * @category "Primitives" "Numbers" "Mathematics"
  * @method "_reinterpreted as float"
- * @param "anInt32" "[-2147483648..2147483647]"
+ * @param "anInt32" "i32"
  *        A 32-bit signed integer.
  * @returns "float"
  *    The single-precision float having the specified bit representation.
@@ -1155,9 +1155,9 @@ Primitive "_mod_" is
  * @method "_⨉_^_"
  * @param "a" "float"
  *        A single-precision floating point number.
- * @param "two" "(2)'s type"
+ * @param "two" "{2}ᵀ"
  *        The number two (`2`).
- * @param "b" "(-∞..∞)"
+ * @param "b" "ℤ"
  *        The scaling factor.
  * @returns "float"
  *    The requested value.
@@ -1179,7 +1179,7 @@ Primitive "_⨉_^_" is
  * @method "_reinterpreted as bits"
  * @param "aFloat" "float"
  *        The float to reinterpret.
- * @returns "[-2147483648..2147483647]"
+ * @returns "i32"
  *    The float's bit representation as a signed 32-bit integer.
  */
 Primitive "_reinterpreted as bits" is
@@ -1195,11 +1195,11 @@ Primitive "_reinterpreted as bits" is
  *
  * @category "Primitives" "Types" "Functions" "Constructors"
  * @method "function accepting_and returning_"
- * @param "parameterTypes" "<(any)'s type…|>"
+ * @param "parameterTypes" "{any}ᵀ*"
  *        The parameter types.
- * @param "returnType" "(⊤)'s type"
+ * @param "returnType" "{⊤}ᵀ"
  *        The return type.
- * @returns "([…]→⊤)'s type"
+ * @returns "{[…]→⊤}ᵀ"
  *    The requested function type. Instances of this type accept arguments
  *    whose types conform to the parameter types and whose return value
  *    conforms to the return type.
@@ -1219,9 +1219,9 @@ Primitive "function accepting_and returning_" is
  *
  * @category "Primitives" "Types" "Functions" "Constructors"
  * @method "[`…]→_"
- * @param "returnType" "(⊤)'s type"
+ * @param "returnType" "{⊤}ᵀ"
  *        A type.
- * @returns "([…]→⊤)'s type"
+ * @returns "{[…]→⊤}ᵀ"
  *    The requested function type. Instances of this type answer values of the
  *    specified return type.
  */
@@ -1240,7 +1240,7 @@ Primitive "[`…]→_" is
  *
  * @category "Primitives" "Functions" "Constructors"
  * @method "new_applying_"
- * @param "aFunctionType" "([…]→⊤)'s type"
+ * @param "aFunctionType" "{[…]→⊤}ᵀ"
  *        The desired function type.
  * @param "functionToApply" "[…]→⊤"
  *        The function that the new function will apply when itself applied with
@@ -1316,9 +1316,9 @@ Primitive "_'s⁇outer variables" is
  *
  * @category "Primitives" "Types" "Functions" "Queries"
  * @method "_'s⁇parameters'type"
- * @param "functionType" "([…]→⊤)'s type"
+ * @param "functionType" "{[…]→⊤}ᵀ"
  *        A function type.
- * @returns "(tuple)'s type"
+ * @returns "{tuple}ᵀ"
  *    A fixed-size tuple type whose element types correspond to the parameter
  *    types of the argument.
  */
@@ -1334,9 +1334,9 @@ Primitive "_'s⁇parameters'type" is
  *
  * @category "Primitives" "Types" "Functions" "Queries"
  * @method "_'s⁇return type"
- * @param "functionType" "([…]→⊤)'s type"
+ * @param "functionType" "{[…]→⊤}ᵀ"
  *        A function type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The return type of the argument.
  */
 Primitive "_'s⁇return type" is
@@ -1370,7 +1370,7 @@ Primitive "Breakpoint" is
  *
  * @category "Primitives" "Time" "Queries"
  * @method "milliseconds since the Epoch"
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The current time as the number of milliseconds which have elapsed since
  *    the Unix Epoch.
  */
@@ -1388,7 +1388,7 @@ Primitive "milliseconds since the Epoch" is
  *
  * @category "Primitives" "Time" "Queries"
  * @method "high-precision timer value"
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The current value of the high-precision timer, in nanoseconds.
  */
 Primitive "high-precision timer value" is
@@ -1455,7 +1455,7 @@ Primitive "_=_" is
  * @method "_'s⁇hash"
  * @param "value" "any"
  *        An arbitrary value.
- * @returns "[-2147483648..2147483647]"
+ * @returns "i32"
  *    The hash value of the argument.
  */
 Primitive "_'s⁇hash" is
@@ -1528,9 +1528,9 @@ Primitive "primitive description of_" is
  *
  * @category "Primitives"
  * @method "_bit test_"
- * @param "value" "(-∞..∞)"
+ * @param "value" "ℤ"
  *        The integer to examine.
- * @param "bitIndex" "[0..∞)"
+ * @param "bitIndex" "𝕎"
  *        The zero-based index of the bit to examine.
  * @returns "boolean"
  *    Whether that bit was 1.
@@ -1548,11 +1548,11 @@ Primitive "_bit test_" is
  *
  * @category "Primitives" "Numbers" "Integers" "Mathematics" "Bits"
  * @method "_bit∧_"
- * @param "arg1" "(-∞..∞)"
+ * @param "arg1" "ℤ"
  *        An integer.
- * @param "arg2" "(-∞..∞)"
+ * @param "arg2" "ℤ"
  *        An integer.
- * @returns "(-∞..∞)"
+ * @returns "ℤ"
  *    The bitwise AND of {@param "arg1"} and {@param "arg2"}.
  */
 Primitive "_bit∧_" is
@@ -1568,11 +1568,11 @@ Primitive "_bit∧_" is
  *
  * @category "Primitives" "Numbers" "Integers" "Mathematics" "Bits"
  * @method "_bit∨_"
- * @param "arg1" "(-∞..∞)"
+ * @param "arg1" "ℤ"
  *        An integer.
- * @param "arg2" "(-∞..∞)"
+ * @param "arg2" "ℤ"
  *        An integer.
- * @returns "(-∞..∞)"
+ * @returns "ℤ"
  *    The bitwise OR of {@param "arg1"} and {@param "arg2"}.
  */
 Primitive "_bit∨_" is
@@ -1588,11 +1588,11 @@ Primitive "_bit∨_" is
  *
  * @category "Primitives" "Numbers" "Integers" "Mathematics" "Bits"
  * @method "_bit⊕_"
- * @param "arg1" "(-∞..∞)"
+ * @param "arg1" "ℤ"
  *        An integer.
- * @param "arg2" "(-∞..∞)"
+ * @param "arg2" "ℤ"
  *        An integer.
- * @returns "(-∞..∞)"
+ * @returns "ℤ"
  *    The bitwise XOR of {@param "arg1"} and {@param "arg2"}.
  */
 Primitive "_bit⊕_" is
@@ -1609,17 +1609,17 @@ Primitive "_bit⊕_" is
  *
  * @category "Primitives" "Numbers" "Types" "Constructors"
  * @method "integer range from_(inclusive=_)to_(inclusive=_)"
- * @param "lowerBound" "[-∞..∞]"
+ * @param "lowerBound" "ℤ∞"
  *        The lower bound.
  * @param "lowerBoundInclusive" "boolean"
  *        `true` if the lower bound should be adjudged inclusive, `false`
  *        otherwise.
- * @param "upperBound" "[-∞..∞]"
+ * @param "upperBound" "ℤ∞"
  *        The upper bound.
  * @param "upperBoundInclusive" "boolean"
  *        `true` if the upper bound should be adjudged inclusive, `false`
  *        otherwise.
- * @returns "([-∞..∞])'s type"
+ * @returns "{ℤ∞}ᵀ"
  *    The requested integral range type.
  */
 Primitive "integer range from_(inclusive=_)to_(inclusive=_)" is
@@ -1637,9 +1637,9 @@ Primitive "integer range from_(inclusive=_)to_(inclusive=_)" is
  *
  * @category "Primitives" "Numbers" "Types" "Queries"
  * @method "_'s⁇genuine lower bound"
- * @param "range" "([-∞..∞])'s type"
+ * @param "range" "{ℤ∞}ᵀ"
  *        An integral range type.
- * @returns "[-∞..∞]"
+ * @returns "ℤ∞"
  *    The lower bound of the argument.
  */
 Primitive "_'s⁇genuine lower bound" is
@@ -1654,9 +1654,9 @@ Primitive "_'s⁇genuine lower bound" is
  *
  * @category "Primitives" "Numbers" "Types" "Queries"
  * @method "_'s⁇genuine upper bound"
- * @param "range" "([-∞..∞])'s type"
+ * @param "range" "{ℤ∞}ᵀ"
  *        An integral range type.
- * @returns "[-∞..∞]"
+ * @returns "ℤ∞"
  *    The upper bound of the argument.
  */
 Primitive "_'s⁇genuine upper bound" is
@@ -1671,7 +1671,7 @@ Primitive "_'s⁇genuine upper bound" is
  *
  * @category "Primitives" "Maps" "Constructors"
  * @method "_→map"
- * @param "bindings" "<<any…|2>…|>"
+ * @param "bindings" "any^[2..2]*"
  *        A tuple of bindings. Each element of the argument is a
  *       2-tuple that represents a binding. The first element of each 2-tuple is
  *       a key, the second element is the value that should be bound to that key
@@ -1692,14 +1692,14 @@ Primitive "_→map" is
  *
  * @category "Primitives" "Types" "Maps" "Constructors"
  * @method "{_→_`|_}"
- * @param "keyType" "(any)'s type"
+ * @param "keyType" "{any}ᵀ"
  *        A type to which all keys of instances must conform.
- * @param "valueType" "(any)'s type"
+ * @param "valueType" "{any}ᵀ"
  *        A type to which all values of instances must conform.
- * @param "cardinalityType" "([0..∞))'s type"
+ * @param "cardinalityType" "{𝕎}ᵀ"
  *        The range of cardinalities to which all instances must
  *       conform.
- * @returns "(map)'s type"
+ * @returns "{map}ᵀ"
  *    The requested map type.
  */
 Primitive "{_→_`|_}" is
@@ -1740,7 +1740,7 @@ Primitive "_∈_" is
  * @method "_'s⁇bindings"
  * @param "aMapType" "map"
  *        A map.
- * @returns "<<any…|2>…|>"
+ * @returns "any^[2..2]*"
  *    The argument's bindings.
  */
 Primitive "_'s⁇bindings" is
@@ -1800,7 +1800,7 @@ Primitive "_+_→_" is
  * @method "`|_`|"
  * @param "aMap" "map"
  *        A map.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The argument's cardinality.
  */
 Primitive "`|_`|" is
@@ -1816,9 +1816,9 @@ Primitive "`|_`|" is
  *
  * @category "Primitives" "Types" "Maps" "Queries"
  * @method "_'s⁇key type"
- * @param "aMapType" "(map)'s type"
+ * @param "aMapType" "{map}ᵀ"
  *        A map type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The argument's key type.
  */
 Primitive "_'s⁇key type" is
@@ -1834,9 +1834,9 @@ Primitive "_'s⁇key type" is
  *
  * @category "Primitives" "Types" "Maps" "Queries"
  * @method "`|`|_`|`|"
- * @param "aMapType" "(map)'s type"
+ * @param "aMapType" "{map}ᵀ"
  *        A map type.
- * @returns "([0..∞))'s type"
+ * @returns "{𝕎}ᵀ"
  *    The argument's cardinality requirement.
  */
 Primitive "`|`|_`|`|" is
@@ -1852,9 +1852,9 @@ Primitive "`|`|_`|`|" is
  *
  * @category "Primitives" "Types" "Maps" "Queries"
  * @method "_'s⁇value type"
- * @param "aMapType" "(map)'s type"
+ * @param "aMapType" "{map}ᵀ"
  *        A map type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The argument's value type.
  */
 Primitive "_'s⁇value type" is
@@ -1911,7 +1911,7 @@ Primitive "_-_" is
  * @method "`|_'s⁇parameters`|"
  * @param "aMessageBundle" "message bundle"
  *        A method.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The number of parameters required by the specified method.
  */
 Primitive "`|_'s⁇parameters`|" is
@@ -1928,7 +1928,7 @@ Primitive "`|_'s⁇parameters`|" is
  * @method "_'s⁇function type"
  * @param "aDefinition" "definition"
  *        Any definition (method, macro, abstract, forward).
- * @returns "([…]→⊤)'s type"
+ * @returns "{[…]→⊤}ᵀ"
  *    The requested function type.
  */
 Primitive "_'s⁇function type" is
@@ -2014,7 +2014,7 @@ Primitive "_'s⁇function" is
  * @method "_'s⁇definitions"
  * @param "aMethod" "method"
  *        An arbitrary {@type "method"}.
- * @returns "<definition…|>"
+ * @returns "definition*"
  *    A {@type "tuple"} of {@type "definition"}s.
  */
 Primitive "_'s⁇definitions" is
@@ -2031,7 +2031,7 @@ Primitive "_'s⁇definitions" is
  * @method "_'s⁇seals"
  * @param "aMethod" "method"
  *        A method.
- * @returns "<<(any)'s type…|>…|>"
+ * @returns "{any}ᵀ**"
  *    A tuple comprising the seals applied to {@param "aMethod"}.
  */
 Primitive "_'s⁇seals" is
@@ -2196,10 +2196,10 @@ Primitive "_→object" is
  *
  * @category "Primitives" "Types" "Objects" "Maps" "Conversions"
  * @method "_→object type"
- * @param "fieldsToTypes" "{atom→(any)'s type|}"
+ * @param "fieldsToTypes" "{atom→{any}ᵀ|}"
  *        A map whose keys are the fields of the new object and whose values are
  *        the corresponding field types.
- * @returns "(object)'s type"
+ * @returns "{object}ᵀ"
  *    The requested object type.
  */
 Primitive "_→object type" is
@@ -2234,7 +2234,7 @@ Primitive "_→map" is
  * @method "_→tuple"
  * @param "anObject" "object"
  *        An object.
- * @returns "<<atom, any…|2>…|>"
+ * @returns "<atom, any…|2>*"
  *    A tuple that represents the composition of the object. Its elements are
  *    2-tuples. Each 2-tuple's first element is an atom (i.e., the field
  *    identifier) and its second element is associated value.
@@ -2253,7 +2253,7 @@ Primitive "_→tuple" is
  *
  * @category "Primitives" "Types" "Objects" "Mutators"
  * @method "_'s⁇name:=_"
- * @param "anObjectType" "(object)'s type"
+ * @param "anObjectType" "{object}ᵀ"
  *        An object type.
  * @param "name" "string"
  *        The name that should be bound to the object type. This will replace
@@ -2277,7 +2277,7 @@ Primitive "_'s⁇name:=_" is
  * @method "Unname_from_"
  * @param "name" "string"
  *        The name that should no longer be bound to the object type.
- * @param "anObjectType" "(object)'s type"
+ * @param "anObjectType" "{object}ᵀ"
  *        An object type.
  * @returns "⊤"
  */
@@ -2294,7 +2294,7 @@ Primitive "Unname_from_" is
  *
  * @category "Primitives" "Tuples" "Objects" "Conversions"
  * @method "_→object"
- * @param "fieldAssignments" "<<atom, any…|2>…|>"
+ * @param "fieldAssignments" "<atom, any…|2>*"
  *        A tuple whose elements are 2-tuples. Each 2-tuple's first element is
  *        an atom (i.e., the field identifier) and its second element is
  *        associated value.
@@ -2313,11 +2313,11 @@ Primitive "_→object" is
  *
  * @category "Primitives" "Types" "Tuples" "Objects" "Conversions"
  * @method "_→object type"
- * @param "fieldDefinitions" "<<atom, (any)'s type…|2>…|>"
+ * @param "fieldDefinitions" "<atom, {any}ᵀ…|2>*"
  *        A tuple whose elements are 2-tuples. Each 2-tuple's first element is
  *        an atom (i.e., the field identifier) and its second element is the
  *        value type permitted by the field.
- * @returns "(object)'s type"
+ * @returns "{object}ᵀ"
  *    The requested object type.
  */
 Primitive "_→object type" is
@@ -2333,7 +2333,7 @@ Primitive "_→object type" is
  *
  * @category "Primitives" "Types" "Objects" "Queries"
  * @method "_'s⁇names"
- * @param "anObjectType" "(object)'s type"
+ * @param "anObjectType" "{object}ᵀ"
  *        An object type.
  * @returns "{string|}"
  *    The set of locally most-specific names bound to the specified object
@@ -2387,7 +2387,7 @@ Primitive "_'s⁇value" is
  * @method "_'s⁇arguments"
  * @param "aBlock" "block phrase⇒[…]→⊤"
  *        A block.
- * @returns "<argument phrase⇒⊤…|>"
+ * @returns "argument phrase⇒⊤*"
  *    A tuple of argument declarations.
  */
 Primitive "_'s⁇arguments" is
@@ -2421,7 +2421,7 @@ Primitive "_'s⁇declared exceptions" is
  * @method "_'s⁇outer variables"
  * @param "aBlock" "block phrase⇒[…]→⊤"
  *        A block.
- * @returns "<declaration phrase⇒⊤…|>"
+ * @returns "declaration phrase⇒⊤*"
  *    A tuple of declarations of outer variables required to complete the
  *    meaning of the block.
  */
@@ -2457,7 +2457,7 @@ Primitive "_'s⁇primitive name" is
  * @method "_'s⁇return type"
  * @param "aBlock" "block phrase⇒[…]→⊤"
  *        A block.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The block's return type.
  */
 Primitive "_'s⁇return type" is
@@ -2474,7 +2474,7 @@ Primitive "_'s⁇return type" is
  * @method "_'s⁇statements"
  * @param "aBlock" "block phrase⇒[…]→⊤"
  *        A block.
- * @returns "<phrase⇒⊤…|>"
+ * @returns "phrase⇒⊤*"
  *    A tuple of statements. These are either assignments, declarations, labels,
  *    sequences, or ⊤-valued sends.
  */
@@ -2492,7 +2492,7 @@ Primitive "_'s⁇statements" is
  * @method "arg`«_:_`»"
  * @param "name" "token"
  *        The name of the new constant.
- * @param "declaredType" "(any)'s type"
+ * @param "declaredType" "{any}ᵀ"
  *        The declared type of the named constant.
  * @returns "argument phrase⇒⊤"
  *    The requested argument declaration.
@@ -2530,7 +2530,7 @@ Primitive "_→statement phrase" is
  * @method "`«_:_:=_`»"
  * @param "name" "token"
  *        The name of the new variable.
- * @param "declaredType" "(any)'s type"
+ * @param "declaredType" "{any}ᵀ"
  *        The declared type of the named variable.
  * @param "initializer" "expression phrase⇒any"
  *        The initialization expression.
@@ -2553,7 +2553,7 @@ Primitive "`«_:_:=_`»" is
  * @method "`«$_:_`»"
  * @param "name" "token"
  *        The name of the label being declared.
- * @param "declaredType" "($[…]→⊥)'s type"
+ * @param "declaredType" "{$[…]→⊥}ᵀ"
  *        The result type of the block containing the label declaration.
  * @returns "label phrase⇒⊤"
  *    The requested label declaration.
@@ -2571,9 +2571,9 @@ Primitive "`«$_:_`»" is
  *
  * @category "Primitives" "Phrases" "Constructors"
  * @method "_→list phrase"
- * @param "aTuple" "<expression phrase⇒any…|>"
+ * @param "aTuple" "expression phrase⇒any*"
  *        A tuple of expressions.
- * @returns "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @returns "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *    The requested list.
  */
 Primitive "_→list phrase" is
@@ -2605,9 +2605,9 @@ Primitive "_→literal phrase" is
  *
  * @category "Primitives" "Types" "Phrases" "Constructors"
  * @method "literal token⇒_"
- * @param "literalValue" "(any)'s type"
+ * @param "literalValue" "{any}ᵀ"
  *        The literal value's type
- * @returns "(literal token⇒any)'s type"
+ * @returns "{literal token⇒any}ᵀ"
  *    A literal token type.
  */
 Primitive "literal token⇒_" is
@@ -2644,7 +2644,7 @@ Primitive "`«_::=_`»" is
  * @method "`«marker phrase_⇒_`»"
  * @param "value" "any"
  *        The marker phrase's value.
- * @param "expressionType" "(⊤)'s type"
+ * @param "expressionType" "{⊤}ᵀ"
  *        The marker phrase's yield type.
  * @returns "marker phrase⇒⊤"
  *    A marker phrase.
@@ -2682,12 +2682,12 @@ Primitive "`«module variable_(_)`»" is
  *
  * @category "Primitives" "Types" "Phrases" "Constructors"
  * @method "_⇒_"
- * @param "aPhrase" "(phrase⇒⊤)'s type"
+ * @param "aPhrase" "{phrase⇒⊤}ᵀ"
  *        A phrase type.
- * @param "semanticType" "(⊤)'s type"
+ * @param "semanticType" "{⊤}ᵀ"
  *        The semantic type of values producible by phrases that are instances
  *        of the answer.
- * @returns "(phrase⇒⊤)'s type"
+ * @returns "{phrase⇒⊤}ᵀ"
  *    The requested phrase type.
  * @raises "{6}"
  */
@@ -2706,7 +2706,7 @@ Primitive "_⇒_" is
  * @method "primfail`«_:_`»"
  * @param "name" "token"
  *        The name of the new constant.
- * @param "declaredType" "(any)'s type"
+ * @param "declaredType" "{any}ᵀ"
  *        The declared type of the named constant.
  * @returns "primitive failure reason phrase⇒⊤"
  *    The requested primitive failure local constant declaration.
@@ -2743,7 +2743,7 @@ Primitive "sequence-as-expression`«_`»" is
  * @method "`«_:_`»"
  * @param "name" "token"
  *        The name of the new variable.
- * @param "declaredType" "(any)'s type"
+ * @param "declaredType" "{any}ᵀ"
  *        The declared type of the named variable.
  * @returns "local variable phrase⇒⊤"
  *    The requested local variable declaration.
@@ -2819,7 +2819,7 @@ Primitive "_'s⁇token" is
  * @method "_'s⁇declared type"
  * @param "aDeclaration" "declaration phrase⇒⊤"
  *        A declaration.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The requested type.
  */
 Primitive "_'s⁇declared type" is
@@ -2855,7 +2855,7 @@ Primitive "_'s⁇expression" is
  * @method "_'s⁇statements"
  * @param "aFirstOfSequence" "first of sequence phrase⇒⊤"
  *        A first-of-sequence.
- * @returns "<phrase⇒⊤…|>"
+ * @returns "phrase⇒⊤*"
  *    The requested tuple of statements.
  */
 Primitive "_'s⁇statements" is
@@ -2870,9 +2870,9 @@ Primitive "_'s⁇statements" is
  *
  * @category "Primitives" "Phrases" "Queries"
  * @method "_'s⁇expressions"
- * @param "aList" "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @param "aList" "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *        A list.
- * @returns "<expression phrase⇒any…|>"
+ * @returns "expression phrase⇒any*"
  *    The requested tuple of expressions.
  */
 Primitive "_'s⁇expressions" is
@@ -2905,9 +2905,9 @@ Primitive "_'s⁇token" is
  *
  * @category "Primitives" "Types" "Phrases" "Queries"
  * @method "_'s⁇value type"
- * @param "literalTokenType" "(literal token⇒any)'s type"
+ * @param "literalTokenType" "{literal token⇒any}ᵀ"
  *        The literal token type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The type of value that such a literal token can produce.
  */
 Primitive "_'s⁇value type" is
@@ -2957,9 +2957,9 @@ Primitive "_'s⁇value" is
  *
  * @category "Primitives"
  * @method "_'s⁇list"
- * @param "permuted" "permuted list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @param "permuted" "permuted list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *        A {@type "permuted list phrase"}.
- * @returns "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @returns "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *    The {@type "list phrase"} permuted by {@param "permuted"}.
  */
 Primitive "_'s⁇list" is
@@ -2975,9 +2975,9 @@ Primitive "_'s⁇list" is
  *
  * @category "Primitives"
  * @method "_'s⁇permutation"
- * @param "permuted" "permuted list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @param "permuted" "permuted list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *        A {@type "permuted list phrase"}.
- * @returns "<[1..∞)…|1..∞>"
+ * @returns "ℕ+"
  *    The permutation {@type "tuple"}. This comprises the target indices,
  *    indexed by source index.
  */
@@ -2997,7 +2997,7 @@ Primitive "_'s⁇permutation" is
  * @method "_'s⁇semantic type"
  * @param "phrase" "phrase⇒⊤"
  *        A phrase.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    A type that describes all values producible by evaluations of the
  *    argument.
  */
@@ -3016,7 +3016,7 @@ Primitive "_'s⁇semantic type" is
  * @method "_'s⁇tokens"
  * @param "phrase" "phrase⇒⊤"
  *        The phrase to examine.
- * @returns "<token…|>"
+ * @returns "token*"
  *          The supplied phrase's tuple of tokens.
  */
 Primitive "_'s⁇tokens" is
@@ -3031,9 +3031,9 @@ Primitive "_'s⁇tokens" is
  *
  * @category "Primitives" "Phrases" "Queries"
  * @method "_'s⁇semantic type"
- * @param "phraseType" "(phrase⇒⊤)'s type"
+ * @param "phraseType" "{phrase⇒⊤}ᵀ"
  *        A phrase type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The requested semantic type.
  */
 Primitive "_'s⁇semantic type" is
@@ -3067,7 +3067,7 @@ Primitive "`«↓_`»" is
  * @method "_'s⁇arguments"
  * @param "aSend" "send phrase⇒⊤"
  *        A message send.
- * @returns "list phrase⇒tuple (subexpressions tuple type=<phrase⇒any…|>)"
+ * @returns "list phrase⇒tuple (subexpressions tuple type=phrase⇒any*)"
  *    The requested list of argument expressions.
  */
 Primitive "_'s⁇arguments" is
@@ -3118,7 +3118,7 @@ Primitive "_'s⁇method" is
  * @method "_'s⁇return type"
  * @param "aSend" "send phrase⇒⊤"
  *        A message send.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The requested type.
  */
 Primitive "_'s⁇return type" is
@@ -3152,7 +3152,7 @@ Primitive "_'s⁇sequence" is
  * @method "_'s⁇statements"
  * @param "aSequence" "sequence phrase⇒⊤"
  *        A sequence.
- * @returns "<phrase⇒⊤…|>"
+ * @returns "phrase⇒⊤*"
  *    The requested tuple of statements.
  */
 Primitive "_'s⁇statements" is
@@ -3187,7 +3187,7 @@ Primitive "_'s⁇expression" is
  * @method "_'s⁇lookup type"
  * @param "aSupercast" "super cast phrase⇒any"
  *        The supercast from which to extract the lookup type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The type that the supercast uses during method lookup.
  */
 Primitive "_'s⁇lookup type" is
@@ -3205,7 +3205,7 @@ Primitive "_'s⁇lookup type" is
  * @method "_'s⁇lexeme"
  * @param "aToken" "token"
  *        A token.
- * @returns "<character…|1..∞>"
+ * @returns "character+"
  *    The source text of {@param "aToken"}.
  */
 Primitive "_'s⁇lexeme" is
@@ -3223,7 +3223,7 @@ Primitive "_'s⁇lexeme" is
  * @method "_'s⁇line number"
  * @param "aToken" "token"
  *        A token.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The one-based line number of {@param "aToken"}.
  */
 Primitive "_'s⁇line number" is
@@ -3241,7 +3241,7 @@ Primitive "_'s⁇line number" is
  * @method "_'s⁇starting position"
  * @param "aToken" "token"
  *        A token.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The zero-based starting position of {@param "aToken"}.
  */
 Primitive "_'s⁇starting position" is
@@ -3291,9 +3291,9 @@ Primitive "_'s⁇token" is
  *
  * @category "Primitives" "POJO" "Constructors"
  * @method "new_[_]"
- * @param "elementType" "(any)'s type"
+ * @param "elementType" "{any}ᵀ"
  *        The element type.
- * @param "length" "[0..∞)"
+ * @param "length" "𝕎"
  *        The number of elements.
  * @returns "any[]"
  *    A new pojo array that can store and answer {@param "length"} elements conforming
@@ -3313,11 +3313,11 @@ Primitive "new_[_]" is
  *
  * @category "Primitives" "Types" "POJO" "Constructors"
  * @method "_[_]"
- * @param "elementType" "(any)'s type"
+ * @param "elementType" "{any}ᵀ"
  *        The type of the elements of instances.
- * @param "cardinalityRequirement" "([0..∞))'s type"
+ * @param "cardinalityRequirement" "{𝕎}ᵀ"
  *        The range of sizes of instances.
- * @returns "(any[])'s type"
+ * @returns "{any[]}ᵀ"
  *    The requested pojo array type.
  */
 Primitive "_[_]" is
@@ -3353,7 +3353,7 @@ Primitive "_→tuple" is
  * @method "`|_`|"
  * @param "anArray" "any[]"
  *        A pojo array.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The size of the argument.
  */
 Primitive "`|_`|" is
@@ -3368,9 +3368,9 @@ Primitive "`|_`|" is
  *
  * @category "Primitives" "Types" "POJO" "Queries"
  * @method "_'s⁇element type"
- * @param "pojoArrayType" "(any[])'s type"
+ * @param "pojoArrayType" "{any[]}ᵀ"
  *        A pojo array type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The element type of {@param "pojoArrayType"}.
  */
 Primitive "_'s⁇element type" is
@@ -3385,9 +3385,9 @@ Primitive "_'s⁇element type" is
  *
  * @category "Primitives" "Types" "POJO" "Queries"
  * @method "`|`|_`|`|"
- * @param "pojoArrayType" "(any[])'s type"
+ * @param "pojoArrayType" "{any[]}ᵀ"
  *        A pojo array type.
- * @returns "([0..∞))'s type"
+ * @returns "{𝕎}ᵀ"
  *    The cardinality restriction of {@param "pojoArrayType"}.
  */
 Primitive "`|`|_`|`|" is
@@ -3405,7 +3405,7 @@ Primitive "`|`|_`|`|" is
  * @method "_'s⁇function type"
  * @param "aFunctionImplementation" "¢[…]→⊤"
  *        A function implementation.
- * @returns "([…]→⊤)'s type"
+ * @returns "{[…]→⊤}ᵀ"
  *    The argument's function type.
  */
 Primitive "_'s⁇function type" is
@@ -3440,7 +3440,7 @@ Primitive "_'s⁇literals" is
  * @method "_'s⁇arity"
  * @param "aFunctionImplementation" "¢[…]→⊤"
  *        A function implementation.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The argument's arity.
  */
 Primitive "_'s⁇arity" is
@@ -3457,7 +3457,7 @@ Primitive "_'s⁇arity" is
  * @method "`|_'s⁇local variables`|"
  * @param "aFunctionImplementation" "¢[…]→⊤"
  *        A function implementation.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The number of locals used by the argument.
  */
 Primitive "`|_'s⁇local variables`|" is
@@ -3474,7 +3474,7 @@ Primitive "`|_'s⁇local variables`|" is
  * @method "`|_'s⁇outer variables`|"
  * @param "aFunctionImplementation" "¢[…]→⊤"
  *        A function implementation.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The number of outers used by the argument.
  */
 Primitive "`|_'s⁇outer variables`|" is
@@ -3493,7 +3493,7 @@ Primitive "`|_'s⁇outer variables`|" is
  * @method "_'s⁇maximum stack depth"
  * @param "aFunctionImplementation" "¢[…]→⊤"
  *        A function implementation.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The argument's maximum stack depth.
  */
 Primitive "_'s⁇maximum stack depth" is
@@ -3511,7 +3511,7 @@ Primitive "_'s⁇maximum stack depth" is
  * @method "_'s⁇nybblecodes"
  * @param "aFunctionImplementation" "¢[…]→⊤"
  *        A function implementation.
- * @returns "<[0..15]…|>"
+ * @returns "[0..15]*"
  *    The argument's nybblecodes.
  */
 Primitive "_'s⁇nybblecodes" is
@@ -3569,7 +3569,7 @@ Primitive "_'s⁇primitive name" is
  * @method "Set name of function implementation_to_"
  * @param "rawFunction" "¢[…]→⊤"
  *        The function implementation to name.
- * @param "name" "<character…|1..∞>"
+ * @param "name" "character+"
  *        A string used to name the function implementation.
  * @returns "⊤"
  */
@@ -3587,11 +3587,11 @@ Primitive "Set name of function implementation_to_" is
  *
  * @category "Primitives" "Types" "Sets" "Constructors"
  * @method "{_`|_}"
- * @param "elementType" "(any)'s type"
+ * @param "elementType" "{any}ᵀ"
  *        The element type.
- * @param "cardinalityType" "([0..∞))'s type"
+ * @param "cardinalityType" "{𝕎}ᵀ"
  *        The range of allowed cardinalities.
- * @returns "(set)'s type"
+ * @returns "{set}ᵀ"
  *    The requested set type. Instances have elements that conform to
  *    {@param "elementType"} and cardinalities that conform to {@param
  *    "cardinalityType"}.
@@ -3697,7 +3697,7 @@ Primitive "_⊆_" is
  * @method "`|_`|"
  * @param "aSet" "set"
  *        A set.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The argument's cardinality.
  */
 Primitive "`|_`|" is
@@ -3732,9 +3732,9 @@ Primitive "_→tuple" is
  *
  * @category "Primitives" "Types" "Sets" "Queries"
  * @method "_'s⁇element|member type"
- * @param "aSetType" "(set)'s type"
+ * @param "aSetType" "{set}ᵀ"
  *        A set type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The argument's element type.
  */
 Primitive "_'s⁇element|member type" is
@@ -3750,9 +3750,9 @@ Primitive "_'s⁇element|member type" is
  *
  * @category "Primitives" "Types" "Sets" "Queries"
  * @method "`|`|_`|`|"
- * @param "aSetType" "(set)'s type"
+ * @param "aSetType" "{set}ᵀ"
  *        A set type.
- * @returns "([0..∞))'s type"
+ * @returns "{𝕎}ᵀ"
  *    The argument's cardinality requirement.
  */
 Primitive "`|`|_`|`|" is
@@ -3851,7 +3851,7 @@ Primitive "_→set" is
  *
  * @category "Primitives" "Tuples" "Transformers"
  * @method "concatenate_"
- * @param "tupleOfTuples" "<tuple…|>"
+ * @param "tupleOfTuples" "tuple*"
  *        A tuple of tuples.
  * @returns "tuple"
  *    The requested tuple.
@@ -3869,13 +3869,13 @@ Primitive "concatenate_" is
  *
  * @category "Primitives" "Types" "Tuples" "Constructors"
  * @method "<_,_`…`|_>"
- * @param "leadingTypes" "<(any)'s type…|>"
+ * @param "leadingTypes" "{any}ᵀ*"
  *        The leading types.
- * @param "defaultType" "(any)'s type"
+ * @param "defaultType" "{any}ᵀ"
  *        The default type.
- * @param "cardinalityType" "([0..∞))'s type"
+ * @param "cardinalityType" "{𝕎}ᵀ"
  *        The range of allowed cardinalities.
- * @returns "(tuple)'s type"
+ * @returns "{tuple}ᵀ"
  *    The requested tuple type.
  */
 Primitive "<_,_`…`|_>" is
@@ -3911,7 +3911,7 @@ Primitive "_reversed" is
  * @method "`|_`|"
  * @param "aTuple" "tuple"
  *        A tuple.
- * @returns "[0..∞)"
+ * @returns "𝕎"
  *    The argument's cardinality.
  */
 Primitive "`|_`|" is
@@ -3928,11 +3928,11 @@ Primitive "`|_`|" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "_[_]"
- * @param "aTupleType" "(tuple)'s type"
+ * @param "aTupleType" "{tuple}ᵀ"
  *        A tuple type.
- * @param "index" "[1..∞)"
+ * @param "index" "ℕ"
  *        The index of the desired element type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The requested element type, or ⊥ if {@param "index"} is out of bounds.
  */
 Primitive "_[_]" is
@@ -3948,13 +3948,13 @@ Primitive "_[_]" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "∪_[_.._]"
- * @param "aTupleType" "(tuple)'s type"
+ * @param "aTupleType" "{tuple}ᵀ"
  *        A tuple type.
- * @param "startIndex" "[1..∞)"
+ * @param "startIndex" "ℕ"
  *        The one-based index (inclusive) of the start of the range.
  * @param "endIndex" "[0..∞]"
  *        The one-based index (inclusive) of the end of the range.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The type union of all element types in the specified range.
  */
 Primitive "∪_[_.._]" is
@@ -3973,11 +3973,11 @@ Primitive "∪_[_.._]" is
  *
  * @category "Primitives" "Types" "Tuples" "Transformers"
  * @method "_++_"
- * @param "arg1" "(tuple)'s type"
+ * @param "arg1" "{tuple}ᵀ"
  *        A tuple type.
- * @param "arg2" "(tuple)'s type"
+ * @param "arg2" "{tuple}ᵀ"
  *        A tuple type.
- * @returns "(tuple)'s type"
+ * @returns "{tuple}ᵀ"
  *    The requested tuple type.
  */
 Primitive "_++_" is
@@ -3993,9 +3993,9 @@ Primitive "_++_" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "_'s⁇default type"
- * @param "aTupleType" "(tuple)'s type"
+ * @param "aTupleType" "{tuple}ᵀ"
  *        A tuple type.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The argument's default element type.
  */
 Primitive "_'s⁇default type" is
@@ -4011,9 +4011,9 @@ Primitive "_'s⁇default type" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "_'s⁇leading types"
- * @param "aTupleType" "(tuple)'s type"
+ * @param "aTupleType" "{tuple}ᵀ"
  *        A tuple type.
- * @returns "<(any)'s type…|>"
+ * @returns "{any}ᵀ*"
  *    The argument's leading element types.
  */
 Primitive "_'s⁇leading types" is
@@ -4028,9 +4028,9 @@ Primitive "_'s⁇leading types" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "`|`|_`|`|"
- * @param "aTupleType" "(tuple)'s type"
+ * @param "aTupleType" "{tuple}ᵀ"
  *        A tuple type.
- * @returns "([0..∞))'s type"
+ * @returns "{𝕎}ᵀ"
  *    The argument's cardinality requirement.
  */
 Primitive "`|`|_`|`|" is
@@ -4046,9 +4046,9 @@ Primitive "`|`|_`|`|" is
  *
  * @category "Primitives" "Types" "Tuples" "Queries"
  * @method "∪_"
- * @param "tupleOfTypes" "<(⊤)'s type…|>"
+ * @param "tupleOfTypes" "{⊤}ᵀ*"
  *        A tuple of types.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The type union of the elements of the argument.
  */
 Primitive "∪_" is
@@ -4094,7 +4094,7 @@ Primitive "Cast|cast_into_else_" is
  * @method "enumeration of_"
  * @param "instances" "set"
  *        The complete set of instances of the enumeration.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The requested enumeration.
  */
 Primitive "enumeration of_" is
@@ -4110,7 +4110,7 @@ Primitive "enumeration of_" is
  *
  * @category "Primitives" "Types" "Queries"
  * @method "`|_`|"
- * @param "aType" "(⊤)'s type"
+ * @param "aType" "{⊤}ᵀ"
  *        A type.
  * @returns "[0..∞]"
  *    The cardinality of the membership of the type.
@@ -4129,7 +4129,7 @@ Primitive "`|_`|" is
  * @method "_∈_"
  * @param "value" "any"
  *        The value to test for membership in {@param "aType"}.
- * @param "aType" "(⊤)'s type"
+ * @param "aType" "{⊤}ᵀ"
  *        The target type for the membership check.
  * @returns "boolean"
  *    {@method "true"} if {@param "value"} is an instance of {@param
@@ -4150,9 +4150,9 @@ Primitive "_∈_" is
  *
  * @category "Primitives" "Types" "Mathematics" "Relations"
  * @method "_⊆_"
- * @param "arg1" "(⊤)'s type"
+ * @param "arg1" "{⊤}ᵀ"
  *        A type.
- * @param "arg2" "(⊤)'s type"
+ * @param "arg2" "{⊤}ᵀ"
  *        A type.
  * @returns "boolean"
  *    `true` if the first argument is a subtype of, or the same type as, the
@@ -4174,7 +4174,7 @@ Primitive "_⊆_" is
  * @method "_'s⁇type"
  * @param "value" "any"
  *        An arbitrary value.
- * @returns "(any)'s type"
+ * @returns "{any}ᵀ"
  *    The precise instance type of the supplied value.
  */
 Primitive "_'s⁇type" is
@@ -4190,11 +4190,11 @@ Primitive "_'s⁇type" is
  *
  * @category "Primitives" "Types" "Mathematics"
  * @method "_∩_"
- * @param "arg1" "(⊤)'s type"
+ * @param "arg1" "{⊤}ᵀ"
  *        A type.
- * @param "arg2" "(⊤)'s type"
+ * @param "arg2" "{⊤}ᵀ"
  *        A type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The type intersection of the arguments.
  */
 Primitive "_∩_" is
@@ -4211,11 +4211,11 @@ Primitive "_∩_" is
  *
  * @category "Primitives" "Types" "Mathematics"
  * @method "_∪_"
- * @param "arg1" "(⊤)'s type"
+ * @param "arg1" "{⊤}ᵀ"
  *        A type.
- * @param "arg2" "(⊤)'s type"
+ * @param "arg2" "{⊤}ᵀ"
  *        A type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The type union of the arguments.
  */
 Primitive "_∪_" is
@@ -4231,11 +4231,11 @@ Primitive "_∪_" is
  *
  * @category "Primitives" "Variables" "Types" "Constructors"
  * @method "read_/write_"
- * @param "readType" "(⊤)'s type"
+ * @param "readType" "{⊤}ᵀ"
  *        The read type of the variable type.
- * @param "writeType" "(⊤)'s type"
+ * @param "writeType" "{⊤}ᵀ"
  *        The write type of the variable type.
- * @returns "(read ⊤/write ⊥)'s type"
+ * @returns "{read ⊤/write ⊥}ᵀ"
  *    The requested variable type.
  */
 Primitive "read_/write_" is
@@ -4251,7 +4251,7 @@ Primitive "read_/write_" is
  *
  * @category "Primitives" "Variables" "Constructors"
  * @method "new`↑_"
- * @param "containmentType" "(any)'s type"
+ * @param "containmentType" "{any}ᵀ"
  *        The containment type.
  * @returns "read ⊤/write ⊥"
  *    A new variable capable of retrieving and storing values of the specified
@@ -4269,9 +4269,9 @@ Primitive "new`↑_" is
  *
  * @category "Primitives" "Variables" "Types" "Constructors"
  * @method "`↑_"
- * @param "containmentType" "(any)'s type"
+ * @param "containmentType" "{any}ᵀ"
  *        The containment type.
- * @returns "(read ⊤/write ⊥)'s type"
+ * @returns "{read ⊤/write ⊥}ᵀ"
  *    The requested variable type.
  */
 Primitive "`↑_" is
@@ -4305,9 +4305,9 @@ Primitive "_↑is unassigned" is
  *
  * @category "Primitives" "Variables" "Types" "Queries"
  * @method "_'s⁇read type"
- * @param "varType" "(read ⊤/write ⊥)'s type"
+ * @param "varType" "{read ⊤/write ⊥}ᵀ"
  *        A variable type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The most general type that describes values that can be read from
  *    instances of {@param "varType"}.
  */
@@ -4324,9 +4324,9 @@ Primitive "_'s⁇read type" is
  *
  * @category "Primitives" "Variables" "Types" "Queries"
  * @method "_'s⁇write type"
- * @param "varType" "(read ⊤/write ⊥)'s type"
+ * @param "varType" "{read ⊤/write ⊥}ᵀ"
  *        A variable type.
- * @returns "(⊤)'s type"
+ * @returns "{⊤}ᵀ"
  *    The most general type that describes values that can be written to
  *    instances of {@param "varType"}.
  */

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Origin.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Origin.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Primitives.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Primitives.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */
@@ -49,6 +49,7 @@ Names
 	"$_@pc=_stack=_[_]caller=_",
 	"<_,_`…`|_>",
 	"Abstract method_is_",
+	"After the current module is loaded,⁇do_",
 	"After the current module is unloaded,⁇do_",
 	"Alias_to_",
 	"Attempt to join_",

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Special Objects.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Bootstrap.avail/Special Objects.avail
@@ -33,7 +33,7 @@
 /*
  * GENERATED FILE
  * * Generator: avail.tools.bootstrap.BootstrapGenerator
- * * Last Generated: 6/29/23, 10:11 PM
+ * * Last Generated: 8/25/23, 10:57 AM
  *
  * DO NOT MODIFY MANUALLY. ALL MANUAL CHANGES WILL BE LOST.
  */

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Foundation.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Foundation.avail
@@ -83,6 +83,7 @@ Extends
 
 		/* Methods */
 		"Abstract method_is_",
+		"After the current module is loaded,⁇do_",
 		"After the current module is unloaded,⁇do_",
 		"Alias_to_",
 		"Attempt to join_",
@@ -426,7 +427,7 @@ Extends
 		"_≤_",
 		"_⊆_",
 		"_⨉_^_",
-		
+
 		/* Convenient renames. */
 		"extended integer" → "ℤ∞",
 		"integer" → "ℤ",

--- a/avail/distro/src/avail/Avail.avail/Foundation.avail/Lexers.avail
+++ b/avail/distro/src/avail/Avail.avail/Foundation.avail/Lexers.avail
@@ -624,6 +624,7 @@ Private method "read range element from_at_" is
 	};
 	If c2 ∈ escapes then
 	[
+		i++;
 		Exit body with escapes[c2]
 	];
 	If c2 ≠ ¢"(" then

--- a/avail/distro/src/examples/CSV.avail/CSV Language.avail
+++ b/avail/distro/src/examples/CSV.avail/CSV Language.avail
@@ -307,8 +307,7 @@ Public method "Display CSV(as a table«with headers»?)" is
 	Print: text;
 ];
 
-// Define the lexers together, to keep their lexing effects transactional.
-[
+After the current module is loaded, do [
 	/**
 	 * Redefine whitespace to ignore line feeds.
 	 *
@@ -376,4 +375,4 @@ Public method "Display CSV(as a table«with headers»?)" is
 		];
 		{<`end-of-line marker` (chars) @ position:line>}
 	];
-]();
+];

--- a/avail/src/main/kotlin/avail/builder/AvailBuilder.kt
+++ b/avail/src/main/kotlin/avail/builder/AvailBuilder.kt
@@ -1158,7 +1158,7 @@ class AvailBuilder constructor(val runtime: AvailRuntime)
 						commandProblemHandler.handle(problem)
 					}
 				})
-			runtime.runOutermostFunction(fiber, function, emptyList())
+			runtime.runOutermostFunction(fiber, function, emptyList(), false)
 		}
 
 		// If the command was unambiguous, then go ahead and run it.

--- a/avail/src/main/kotlin/avail/builder/BuildLoader.kt
+++ b/avail/src/main/kotlin/avail/builder/BuildLoader.kt
@@ -760,8 +760,8 @@ internal class BuildLoader constructor(
 		bytesCompiled.set(0L)
 		val vertexCountBefore = availBuilder.moduleGraph.vertexCount
 		availBuilder.moduleGraph.parallelVisitThen(
-			{ vertex, done -> scheduleLoadModule(vertex, done) },
-			{
+			visitAction = { vertex, done -> scheduleLoadModule(vertex, done) },
+			afterTraversal = {
 				try
 				{
 					assert(

--- a/avail/src/main/kotlin/avail/builder/BuildLoader.kt
+++ b/avail/src/main/kotlin/avail/builder/BuildLoader.kt
@@ -50,6 +50,7 @@ import avail.descriptor.functions.A_Function
 import avail.descriptor.functions.A_RawFunction.Companion.codeStartingLineNumber
 import avail.descriptor.functions.A_RawFunction.Companion.methodName
 import avail.descriptor.functions.A_RawFunction.Companion.module
+import avail.descriptor.functions.A_RawFunction.Companion.numArgs
 import avail.descriptor.module.A_Module.Companion.getAndSetTupleOfBlockPhrases
 import avail.descriptor.module.A_Module.Companion.phrasePathRecord
 import avail.descriptor.module.A_Module.Companion.removeFrom
@@ -59,6 +60,7 @@ import avail.descriptor.module.A_Module.Companion.setNamesIndexRecordIndex
 import avail.descriptor.module.A_Module.Companion.setPhrasePathRecordIndex
 import avail.descriptor.module.A_Module.Companion.setStylingRecordIndex
 import avail.descriptor.module.A_Module.Companion.shortModuleNameNative
+import avail.descriptor.module.A_Module.Companion.takePostLoadFunctions
 import avail.descriptor.module.ModuleDescriptor
 import avail.descriptor.module.ModuleDescriptor.Companion.newModule
 import avail.descriptor.numbers.IntegerDescriptor.Companion.fromLong
@@ -408,28 +410,26 @@ internal class BuildLoader constructor(
 		// Run each zero-argument block, one after another.
 		recurse { runNext ->
 			availLoader.phase = Phase.LOADING
-			val function: A_Function?
-			try
-			{
-				function =
+			val function: A_Function? = try
+				{
 					if (availBuilder.shouldStopBuild) null
 					else deserializer.deserialize()
-			}
-			catch (e: MalformedSerialStreamException)
-			{
-				fail(e)
-				return@recurse
-			}
-			catch (e: RuntimeException)
-			{
-				fail(e)
-				return@recurse
-			}
-
+				}
+				catch (e: MalformedSerialStreamException)
+				{
+					fail(e)
+					return@recurse
+				}
+				catch (e: RuntimeException)
+				{
+					fail(e)
+					return@recurse
+				}
 			when
 			{
 				function !== null ->
 				{
+					assert(function.code().numArgs() == 0)
 					val fiber = newLoaderFiber(
 						function.kind().returnType,
 						availLoader)
@@ -443,13 +443,13 @@ internal class BuildLoader constructor(
 					}
 					val before = fiber.fiberHelper.fiberTime()
 					fiber.setSuccessAndFailure(
-						{
+						onSuccess = {
 							val after = fiber.fiberHelper.fiberTime()
 							Interpreter.current().recordTopStatementEvaluation(
 								(after - before).toDouble(), module)
 							runNext()
 						},
-						fail)
+						onFailure = fail)
 					availLoader.phase = Phase.EXECUTING_FOR_LOAD
 					if (AvailLoader.debugLoadedStatements)
 					{
@@ -460,7 +460,7 @@ internal class BuildLoader constructor(
 								+ " Running precompiled -- " + function)
 					}
 					availBuilder.runtime.runOutermostFunction(
-						fiber, function, emptyList())
+						fiber, function, emptyList(), true)
 				}
 				availBuilder.shouldStopBuild ->
 					module.removeFrom(availLoader) {
@@ -469,17 +469,39 @@ internal class BuildLoader constructor(
 					}
 				else ->
 				{
-					module.serializedObjects(deserializer.serializedObjects())
-					availBuilder.runtime.addModule(module)
-					val loadedModule = LoadedModule(
-						moduleName,
-						sourceDigest,
-						module,
-						version,
-						compilation)
-					availBuilder.putLoadedModule(moduleName, loadedModule)
-					postLoad(moduleName, 0L)
-					completionAction()
+					// All the functions in the body have run.  Now run any
+					// post-load functions that were accumulated.
+					availLoader.phase = Phase.EXECUTING_FOR_LOAD
+					val functions = module.takePostLoadFunctions()
+					availLoader.runFunctions(
+						functions = functions.iterator(),
+						purpose = "Post-load function (for fast-loader)",
+						afterFailingOne = { failedFunction, e, _ ->
+							// An error has happened in the fiber running a
+							// post-load function.  Report the problem and abort
+							// the load.
+							val line =
+								failedFunction.code().codeStartingLineNumber
+							fail(RuntimeException(
+								"Post-load function at $module:$line failed.",
+								e))
+							// Specifically DO NOT run more functions.
+						},
+						afterRunningAll = {
+							module.serializedObjects(
+								deserializer.serializedObjects())
+							availBuilder.runtime.addModule(module)
+							val loadedModule = LoadedModule(
+								moduleName,
+								sourceDigest,
+								module,
+								version,
+								compilation)
+							availBuilder.putLoadedModule(
+								moduleName, loadedModule)
+							postLoad(moduleName, 0L)
+							completionAction()
+						})
 				}
 			}
 		}

--- a/avail/src/main/kotlin/avail/compiler/AvailCompiler.kt
+++ b/avail/src/main/kotlin/avail/compiler/AvailCompiler.kt
@@ -3451,7 +3451,9 @@ class AvailCompiler constructor(
 					// ...but ensure the final statement styling has completed
 					// before writing to the repository or indicating success.
 					compilationContext.whenNotStyling {
-						reachedEndOfModule(withoutEndToken)
+						runAllPostCompileActionsThen {
+							reachedEndOfModule(withoutEndToken)
+						}
 					}
 				}
 				return@parseOutermostStatement
@@ -3543,6 +3545,23 @@ class AvailCompiler constructor(
 			// executing the top-level statement (i.e., each simple statement).
 			compilationContext.whenNotStyling(recurse)
 		}
+	}
+
+	/**
+	 * The module has been fully parsed, and each statement has been executed.
+	 * Now run any Avail functions that were specifically postponed until after
+	 * parsing.  They must run sequentially, in the order they were recorded.
+	 *
+	 * After the statements have run, execute [afterActions].
+	 *
+	 * @param afterActions
+	 *   What to execute after successfully running all the post-compile
+	 *   functions.
+	 */
+	private fun runAllPostCompileActionsThen(afterActions: ()->Unit)
+	{
+		//TODO
+		afterActions()
 	}
 
 	/**

--- a/avail/src/main/kotlin/avail/compiler/AvailCompilerFragmentCache.kt
+++ b/avail/src/main/kotlin/avail/compiler/AvailCompilerFragmentCache.kt
@@ -32,8 +32,6 @@
 
 package avail.compiler
 
-import java.util.concurrent.ConcurrentHashMap
-
 /**
  * An `AvailCompilerFragmentCache` implements a memoization mechanism for a
  * [compiler][AvailCompiler].  The purpose is to ensure that the effort to parse
@@ -48,11 +46,9 @@ class AvailCompilerFragmentCache
 	 * various positions.  Technically at various
 	 * [parser&#32;states][ParserState], since we must take into account which
 	 * variable declarations are in scope when looking for subexpressions.
-	 *
-	 * This is implemented with a [ConcurrentHashMap] to minimize contention.
 	 */
 	private val solutions =
-		ConcurrentHashMap<ParserState, AvailCompilerBipartiteRendezvous>(100)
+		HashMap<ParserState, AvailCompilerBipartiteRendezvous>(100)
 
 	/**
 	 * Look up the [AvailCompilerBipartiteRendezvous] at the given

--- a/avail/src/main/kotlin/avail/compiler/CompilationContext.kt
+++ b/avail/src/main/kotlin/avail/compiler/CompilationContext.kt
@@ -670,7 +670,7 @@ class CompilationContext constructor(
 		{
 			fiber.setSuccessAndFailure(adjustedSuccess, onFailure)
 		}
-		runtime.runOutermostFunction(fiber, function, args)
+		runtime.runOutermostFunction(fiber, function, args, false)
 	}
 
 	/**
@@ -1185,7 +1185,8 @@ class CompilationContext constructor(
 			stylerFn.ifNil { runtime[DEFAULT_STYLER] },
 			listOf(
 				tupleFromList(listOfNotNull(originalSendPhrase)),
-				transformedPhrase))
+				transformedPhrase),
+			true)
 	}
 
 	/**

--- a/avail/src/main/kotlin/avail/compiler/ParserState.kt
+++ b/avail/src/main/kotlin/avail/compiler/ParserState.kt
@@ -40,6 +40,7 @@ import avail.descriptor.maps.A_Map
 import avail.descriptor.maps.MapDescriptor
 import avail.descriptor.representation.A_BasicObject
 import avail.descriptor.representation.AvailObject
+import avail.descriptor.representation.AvailObject.Companion.combine3
 import avail.descriptor.tuples.A_String.Companion.asNativeString
 import avail.descriptor.tuples.A_String.Companion.copyStringFromToCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
@@ -78,8 +79,10 @@ class ParserState internal constructor(
 	 */
 	val clientDataMap: A_Map = clientDataMap.makeShared()
 
-	override fun hashCode() =
-		lexingState.hashCode() * AvailObject.multiplier xor clientDataMap.hash()
+	override fun hashCode() = combine3(
+		lexingState.hashCode(),
+		clientDataMap.hash(),
+		0x7DC12422)
 
 	override fun equals(other: Any?): Boolean
 	{
@@ -94,9 +97,8 @@ class ParserState internal constructor(
 		// Don't bother comparing allTokens, since there should never be a case
 		// where the lexingState and clientDataMap agree, but different lists of
 		// tokens were accumulated to get there.
-		val anotherState = other as ParserState?
-		return lexingState == anotherState!!.lexingState
-			&& clientDataMap.equals(anotherState.clientDataMap)
+		return lexingState == other.lexingState
+			&& clientDataMap.equals(other.clientDataMap)
 	}
 
 	override fun toString(): String

--- a/avail/src/main/kotlin/avail/compiler/scanning/LexingState.kt
+++ b/avail/src/main/kotlin/avail/compiler/scanning/LexingState.kt
@@ -344,7 +344,7 @@ class LexingState constructor(
 				decrementAndRunActionsWhenZero(countdown)
 			})
 		loader.runtime.runOutermostFunction(
-			fiber, lexer.lexerBodyFunction, arguments)
+			fiber, lexer.lexerBodyFunction, arguments, true)
 	}
 
 	/**
@@ -663,7 +663,8 @@ class LexingState constructor(
 								token.start(),
 								token.lineNumber(),
 								token,
-								token.generatingLexer))))
+								token.generatingLexer))),
+					true)
 			},
 			then = then)
 	}

--- a/avail/src/main/kotlin/avail/compiler/splitter/MessageSplitter.kt
+++ b/avail/src/main/kotlin/avail/compiler/splitter/MessageSplitter.kt
@@ -145,7 +145,8 @@ import kotlin.concurrent.read
  *
  * Construct a new `MessageSplitter`, parsing the provided message into token
  * strings and generating [parsing][ParsingOperation] for parsing occurrences of
- * this message.
+ * this message.  This constructor is private – use [split] instead, since it
+ * makes use of a [cache] for performance.
  *
  * @param messageName
  *   An Avail [string][StringDescriptor] specifying the keywords and arguments
@@ -1523,7 +1524,7 @@ private constructor(messageName: A_String)
 		 * The cache of recently split message names.  The keys are [A_String]s
 		 * which have been [SHARED].
 		 */
-		private val cache = LRUCache(10000, 100, ::MessageSplitter)
+		private val cache = LRUCache(20000, 500, ::MessageSplitter)
 
 		/**
 		 * The [set][A_Set] of all [errors][AvailErrorCode] that can happen

--- a/avail/src/main/kotlin/avail/descriptor/methods/MethodDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/methods/MethodDescriptor.kt
@@ -164,6 +164,7 @@ import avail.interpreter.primitive.methods.P_SimpleLexerDefinitionForAtom
 import avail.interpreter.primitive.methods.P_SimpleMacroDeclaration
 import avail.interpreter.primitive.methods.P_SimpleMacroDefinitionForAtom
 import avail.interpreter.primitive.methods.P_SimpleMethodDeclaration
+import avail.interpreter.primitive.modules.P_AddPostLoadFunction
 import avail.interpreter.primitive.modules.P_AddUnloadFunction
 import avail.interpreter.primitive.modules.P_DeclareAllAtomsExportedFromAnotherModule
 import avail.interpreter.primitive.modules.P_DeclareAllExportedAtoms
@@ -874,8 +875,13 @@ class MethodDescriptor private constructor(
 			"vm_↑-=_",
 			P_AtomicRemoveFromMap),
 
+		/** The special atom for adding a module post-load function. */
+		ADD_POSTLOAD_FUNCTION(
+			"vm on postload_",
+			P_AddPostLoadFunction),
+
 		/** The special atom for adding a module unload function. */
-		ADD_UNLOADER(
+		ADD_UNLOAD_FUNCTION(
 			"vm on unload_",
 			P_AddUnloadFunction),
 

--- a/avail/src/main/kotlin/avail/descriptor/module/A_Module.kt
+++ b/avail/src/main/kotlin/avail/descriptor/module/A_Module.kt
@@ -173,6 +173,20 @@ interface A_Module : A_BasicObject
 
 		/**
 		 * Add the specified [function][A_Function] to the [tuple][A_Tuple] of
+		 * functions that should be applied when the [module][A_Module] has been
+		 * fully compiled.
+		 *
+		 * @param postLoadFunction
+		 *   An Avail [A_Function] of zero arguments.
+		 * @throws AvailRuntimeException
+		 *   If the [module][A_Module] is nat currently loading.
+		 */
+		@Throws(AvailRuntimeException::class)
+		fun A_Module.addPostLoadFunction(postLoadFunction: A_Function) =
+			dispatch { o_AddPostLoadFunction(it, postLoadFunction) }
+
+		/**
+		 * Add the specified [function][A_Function] to the [tuple][A_Tuple] of
 		 * functions that should be applied when the [module][A_Module] is unloaded.
 		 *
 		 * @param unloadFunction

--- a/avail/src/main/kotlin/avail/descriptor/module/A_Module.kt
+++ b/avail/src/main/kotlin/avail/descriptor/module/A_Module.kt
@@ -416,6 +416,13 @@ interface A_Module : A_BasicObject
 			dispatch { o_ResolveForward(it, forwardDefinition) }
 
 		/**
+		 * Remove the [A_Tuple] of post-load [A_Function] from this module,
+		 * returning them.  Replace the tuple with [nil].
+		 */
+		fun A_Module.takePostLoadFunctions(): A_Tuple =
+			dispatch { o_TakePostLoadFunctions(it) }
+
+		/**
 		 * Dispatch to the descriptor.
 		 */
 		fun A_Module.trueNamesForStringName(stringName: A_String): A_Set =

--- a/avail/src/main/kotlin/avail/descriptor/module/ModuleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/module/ModuleDescriptor.kt
@@ -1248,6 +1248,12 @@ class ModuleDescriptor private constructor(
 		return phrasePathRecord!!
 	}
 
+	override fun o_TakePostLoadFunctions(
+		self: AvailObject
+	): A_Tuple = lock.safeWrite {
+		self.getAndSetVolatileSlot(POST_LOAD_FUNCTIONS, nil)
+	}
+
 	override fun o_RemoveFrom(
 		self: AvailObject,
 		loader: AvailLoader,
@@ -1262,7 +1268,7 @@ class ModuleDescriptor private constructor(
 			functions = unloadFunctions.iterator(),
 			purpose = "Unload",
 			afterFailingOne =
-			{ toProceed ->
+			{ _, _, toProceed ->
 				// Log but ignore failures during unload.
 				println(
 					"Failure running unload function for $moduleName. " +

--- a/avail/src/main/kotlin/avail/descriptor/representation/A_BasicObject.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/A_BasicObject.kt
@@ -469,6 +469,11 @@ interface A_BasicObject : JSONFriendly
 	 */
 	fun equalsTwoByteString(aTwoByteString: A_String): Boolean
 
+	/**
+	 * Dispatch to the descriptor.
+	 */
+	fun equalsTwentyOneBitString(aTwentyOneBitString: A_String): Boolean
+
 
 	/**
 	 * Test if the receiver is the [nil][NilDescriptor] value.

--- a/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
@@ -3682,6 +3682,10 @@ abstract class AbstractDescriptor protected constructor (
 
 	abstract fun o_HasValue (self: AvailObject): Boolean
 
+	abstract fun o_AddPostLoadFunction (
+		self: AvailObject,
+		postLoadFunction: A_Function)
+
 	abstract fun o_AddUnloadFunction (
 		self: AvailObject,
 		unloadFunction: A_Function)

--- a/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
@@ -123,6 +123,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithByteTupleStart
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithNybbleTupleStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithObjectTupleStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithStartingAt
+import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithTwentyOneBitStringStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithTwoByteStringStartingAt
 import avail.descriptor.tuples.ByteStringDescriptor
 import avail.descriptor.tuples.ByteTupleDescriptor
@@ -134,6 +135,7 @@ import avail.descriptor.tuples.SmallIntegerIntervalTupleDescriptor
 import avail.descriptor.tuples.StringDescriptor
 import avail.descriptor.tuples.TreeTupleDescriptor
 import avail.descriptor.tuples.TupleDescriptor
+import avail.descriptor.tuples.TwentyOneBitStringDescriptor
 import avail.descriptor.tuples.TwoByteStringDescriptor
 import avail.descriptor.types.A_Type
 import avail.descriptor.types.A_Type.Companion.acceptsArgTypesFromFunctionType
@@ -1380,6 +1382,34 @@ abstract class AbstractDescriptor protected constructor (
 		aTwoByteString: A_String,
 		startIndex2: Int): Boolean
 
+	/**
+	 * Compare a subrange of the [receiver][AvailObject] with a subrange of the
+	 * given [twenty-one-bit&#32;string][TwentyOneBitStringDescriptor]. The size
+	 * of the subrange of both objects is determined by the index range supplied
+	 * for the receiver.
+	 *
+	 * @param self
+	 *   The receiver.
+	 * @param startIndex1
+	 *   The inclusive lower bound of the receiver's subrange.
+	 * @param endIndex1
+	 *   The inclusive upper bound of the receiver's subrange.
+	 * @param aTwentyOneBitString
+	 *   The two-byte string used in the comparison.
+	 * @param startIndex2
+	 *   The inclusive lower bound of the two-byte string's subrange.
+	 * @return
+	 *   `true` if the contents of the subranges match exactly, `false`
+	 *   otherwise.
+	 * @see A_Tuple.compareFromToWithTwentyOneBitStringStartingAt
+	 */
+	abstract fun o_CompareFromToWithTwentyOneBitStringStartingAt (
+		self: AvailObject,
+		startIndex1: Int,
+		endIndex1: Int,
+		aTwentyOneBitString: A_String,
+		startIndex2: Int): Boolean
+
 	abstract fun o_ComputeHashFromTo (
 		self: AvailObject,
 		start: Int,
@@ -1786,6 +1816,10 @@ abstract class AbstractDescriptor protected constructor (
 	abstract fun o_ReleaseFromDebugger(self: AvailObject)
 
 	abstract fun o_RemoveDependentChunk (self: AvailObject, chunk: L2Chunk)
+
+	abstract fun o_TakePostLoadFunctions (
+		self: AvailObject
+	): A_Tuple
 
 	abstract fun o_RemoveFrom (
 		self: AvailObject,
@@ -2580,6 +2614,10 @@ abstract class AbstractDescriptor protected constructor (
 	abstract fun o_EqualsTwoByteString (
 		self: AvailObject,
 		aString: A_String): Boolean
+
+	abstract fun o_EqualsTwentyOneBitString (
+		self: AvailObject,
+		aTwentyOneBitString: A_String): Boolean
 
 	abstract fun o_HasObjectInstance (
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/representation/AvailObject.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AvailObject.kt
@@ -611,6 +611,9 @@ class AvailObject private constructor(
 	override fun equalsTwoByteString(aTwoByteString: A_String) =
 		descriptor().o_EqualsTwoByteString(this, aTwoByteString)
 
+	override fun equalsTwentyOneBitString(aTwentyOneBitString: A_String) =
+		descriptor().o_EqualsTwentyOneBitString(this, aTwentyOneBitString)
+
 	override fun fieldMap() = descriptor().o_FieldMap(this)
 
 	@Throws(VariableGetException::class)

--- a/avail/src/main/kotlin/avail/descriptor/representation/AvailObjectRepresentation.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AvailObjectRepresentation.kt
@@ -841,12 +841,9 @@ sealed class AvailObjectRepresentation constructor(
 				while (true)
 				{
 					val oldValue = objectSlots[arrayIndex]!!
-					val newValue = updater(oldValue) as AvailObject
+					val newValue = updater(oldValue).makeShared()
 					if (VolatileSlotHelper.compareAndSet(
-							objectSlots,
-							arrayIndex,
-							oldValue,
-							newValue.makeShared()))
+							objectSlots, arrayIndex, oldValue, newValue))
 					{
 						return newValue
 					}
@@ -854,6 +851,7 @@ sealed class AvailObjectRepresentation constructor(
 			}
 			else ->
 			{
+				// If the receiver isn't shared, there's no contention.
 				val newValue = updater(objectSlots[arrayIndex]!!) as AvailObject
 				objectSlots[arrayIndex] = newValue
 				return newValue
@@ -894,9 +892,8 @@ sealed class AvailObjectRepresentation constructor(
 				{
 					val oldValue = longSlots[arrayIndex]
 					newValue = updater(oldValue)
-				}
-				while (!VolatileSlotHelper.compareAndSet(
-						longSlots, arrayIndex, oldValue, newValue))
+				} while (!VolatileSlotHelper.compareAndSet(
+					longSlots, arrayIndex, oldValue, newValue))
 				return newValue
 			}
 			else ->

--- a/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
@@ -183,6 +183,10 @@ protected constructor (
 		self: AvailObject,
 		chunk: L2Chunk): Unit = unsupported
 
+	override fun o_AddPostLoadFunction (
+		self: AvailObject,
+		postLoadFunction: A_Function): Unit = unsupported
+
 	override fun o_AddUnloadFunction (
 		self: AvailObject,
 		unloadFunction: A_Function): Unit = unsupported

--- a/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
@@ -412,6 +412,14 @@ protected constructor (
 		aTwoByteString: A_String,
 		startIndex2: Int): Boolean = unsupported
 
+	override fun o_CompareFromToWithTwentyOneBitStringStartingAt(
+		self: AvailObject,
+		startIndex1: Int,
+		endIndex1: Int,
+		aTwentyOneBitString: A_String,
+		startIndex2: Int
+	): Boolean = unsupported
+
 	override fun o_ComputeHashFromTo (
 		self: AvailObject,
 		start: Int,
@@ -669,6 +677,10 @@ protected constructor (
 	override fun o_RemoveDependentChunk (
 		self: AvailObject,
 		chunk: L2Chunk): Unit = unsupported
+
+	override fun o_TakePostLoadFunctions (
+		self: AvailObject
+	): A_Tuple = unsupported
 
 	override fun o_RemoveFrom (
 		self: AvailObject,
@@ -1257,6 +1269,10 @@ protected constructor (
 	override fun o_EqualsTwoByteString (
 		self: AvailObject,
 		aString: A_String) = false
+
+	override fun o_EqualsTwentyOneBitString (
+		self: AvailObject,
+		aTwentyOneBitString: A_String) = false
 
 	override fun o_HasObjectInstance (
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
@@ -248,6 +248,7 @@ import avail.descriptor.module.A_Module.Companion.addConstantBinding
 import avail.descriptor.module.A_Module.Companion.addImportedName
 import avail.descriptor.module.A_Module.Companion.addImportedNames
 import avail.descriptor.module.A_Module.Companion.addLexer
+import avail.descriptor.module.A_Module.Companion.addPostLoadFunction
 import avail.descriptor.module.A_Module.Companion.addPrivateName
 import avail.descriptor.module.A_Module.Companion.addPrivateNames
 import avail.descriptor.module.A_Module.Companion.addSeal
@@ -3372,6 +3373,11 @@ class IndirectionDescriptor private constructor(
 
 	override fun o_HasValue(self: AvailObject): Boolean =
 		self .. { hasValue() }
+
+	override fun o_AddPostLoadFunction(
+		self: AvailObject,
+		postLoadFunction: A_Function
+	) = self .. { addPostLoadFunction(postLoadFunction) }
 
 	override fun o_AddUnloadFunction(
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
@@ -291,6 +291,7 @@ import avail.descriptor.module.A_Module.Companion.setStylingRecordIndex
 import avail.descriptor.module.A_Module.Companion.shortModuleNameNative
 import avail.descriptor.module.A_Module.Companion.stylers
 import avail.descriptor.module.A_Module.Companion.stylingRecord
+import avail.descriptor.module.A_Module.Companion.takePostLoadFunctions
 import avail.descriptor.module.A_Module.Companion.trueNamesForStringName
 import avail.descriptor.module.A_Module.Companion.variableBindings
 import avail.descriptor.module.A_Module.Companion.versions
@@ -483,6 +484,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithObjectTupleSta
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithRepeatedElementTupleStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithSmallIntegerIntervalTupleStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithStartingAt
+import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithTwentyOneBitStringStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithTwoByteStringStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.computeHashFromTo
 import avail.descriptor.tuples.A_Tuple.Companion.concatenateTuplesCanDestroy
@@ -1141,6 +1143,17 @@ class IndirectionDescriptor private constructor(
 			startIndex1, endIndex1, aTwoByteString, startIndex2)
 	}
 
+	override fun o_CompareFromToWithTwentyOneBitStringStartingAt(
+		self: AvailObject,
+		startIndex1: Int,
+		endIndex1: Int,
+		aTwentyOneBitString: A_String,
+		startIndex2: Int
+	): Boolean = self .. {
+		compareFromToWithTwentyOneBitStringStartingAt(
+			startIndex1, endIndex1, aTwentyOneBitString, startIndex2)
+	}
+
 	override fun o_ComputeHashFromTo(
 		self: AvailObject,
 		start: Int,
@@ -1371,6 +1384,11 @@ class IndirectionDescriptor private constructor(
 		self: AvailObject,
 		aString: A_String
 	): Boolean = self .. { equalsTwoByteString(aString) }
+
+	override fun o_EqualsTwentyOneBitString(
+		self: AvailObject,
+		aTwentyOneBitString: A_String
+	): Boolean = self .. { equalsTwentyOneBitString(aTwentyOneBitString) }
 
 	override fun o_SetExecutionState(
 		self: AvailObject,
@@ -1796,6 +1814,10 @@ class IndirectionDescriptor private constructor(
 	): A_Number = self .. {
 		subtractFromIntegerCanDestroy(anInteger, canDestroy)
 	}
+
+	override fun o_TakePostLoadFunctions (
+		self: AvailObject
+	): A_Tuple = self .. { takePostLoadFunctions() }
 
 	override fun o_TimesCanDestroy(
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/tuples/A_Tuple.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/A_Tuple.kt
@@ -503,6 +503,34 @@ interface A_Tuple : A_BasicObject, Iterable<AvailObject>
 		}
 
 		/**
+		 * Compare a subrange of the [receiver][AvailObject] with a subrange of
+		 * the given [twenty-one-bit string][TwentyOneBitStringDescriptor]. The
+		 * size of the subrange of both objects is determined by the index range
+		 * supplied for the receiver.
+		 *
+		 * @param startIndex1
+		 *   The inclusive lower bound of the receiver's subrange.
+		 * @param endIndex1
+		 *   The inclusive upper bound of the receiver's subrange.
+		 * @param aTwentyOneBitString
+		 *   The twenty-one-bit string used in the comparison.
+		 * @param startIndex2
+		 *   The inclusive lower bound of the twenty-one-bit string's subrange.
+		 * @return
+		 *   `true` if the contents of the subranges match exactly, `false`
+		 *   otherwise.
+		 */
+		fun A_Tuple.compareFromToWithTwentyOneBitStringStartingAt(
+			startIndex1: Int,
+			endIndex1: Int,
+			aTwentyOneBitString: A_String,
+			startIndex2: Int
+		): Boolean = dispatch {
+			o_CompareFromToWithTwentyOneBitStringStartingAt(
+				it, startIndex1, endIndex1, aTwentyOneBitString, startIndex2)
+		}
+
+		/**
 		 * Compute the hash of the specified subrange of this tuple.
 		 *
 		 * @param start

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ByteStringDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ByteStringDescriptor.kt
@@ -501,18 +501,15 @@ class ByteStringDescriptor private constructor(
 	override fun o_TupleReverse(self: AvailObject): A_Tuple
 	{
 		val size = self.tupleSize
-		return if (size > maximumCopySize)
-		{
-			super.o_TupleReverse(self)
-		}
-		else generateByteString(size) {
-			self.byteSlot(RAW_LONGS_, size + 1 - it).toInt()
-		}
+		if (size > maximumCopySize) return super.o_TupleReverse(self)
 
 		// It's not empty, it's not a total copy, and it's reasonably small.
 		// Just copy the applicable bytes out.  In theory we could use
 		// newLike() if start is 1.  Make sure to mask the last word in that
 		// case.
+		return generateByteString(size) {
+			self.byteSlot(RAW_LONGS_, size + 1 - it).toInt()
+		}
 	}
 
 	// Answer the number of elements in the object.

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ByteTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ByteTupleDescriptor.kt
@@ -490,16 +490,15 @@ class ByteTupleDescriptor private constructor(
 	override fun o_TupleReverse(self: AvailObject): A_Tuple
 	{
 		val tupleSize = self.tupleSize
-		if (tupleSize in 1 until maximumCopySize)
+		if (tupleSize >= maximumCopySize)
 		{
-			// It's not empty and it's reasonably small.
-			var sourceIndex = tupleSize
-			return generateByteTupleFrom(tupleSize) {
-				self.byteSlot(
-					RAW_LONG_AT_, sourceIndex--).toInt()
-			}
+			return super.o_TupleReverse(self)
 		}
-		return super.o_TupleReverse(self)
+		// It's not empty and it's reasonably small.
+		var sourceIndex = tupleSize
+		return generateByteTupleFrom(tupleSize) {
+			self.byteSlot(RAW_LONG_AT_, sourceIndex--).toInt()
+		}
 	}
 
 	override fun o_TupleSize(self: AvailObject): Int =

--- a/avail/src/main/kotlin/avail/descriptor/tuples/IntegerIntervalTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/IntegerIntervalTupleDescriptor.kt
@@ -193,7 +193,7 @@ class IntegerIntervalTupleDescriptor private constructor(mutability: Mutability)
 				else newLike(mutable, self, 0, 0)
 			result[END] = newElement
 			result[SIZE] = originalSize + 1
-			result[HASH_OR_ZERO] = 0 
+			result[HASH_OR_ZERO] = 0
 			return result
 		}
 		// Transition to a tree tuple.
@@ -497,8 +497,7 @@ class IntegerIntervalTupleDescriptor private constructor(mutability: Mutability)
 		//If tuple is small enough or is immutable, create a new Interval
 		if (self.tupleSize < maximumCopySize || !isMutable)
 		{
-			val newDelta =
-				self[DELTA].timesCanDestroy(fromInt(-1), true)
+			val newDelta = self[DELTA].timesCanDestroy(fromInt(-1), true)
 			return forceCreate(
 				self[END],
 				self[START],
@@ -509,8 +508,7 @@ class IntegerIntervalTupleDescriptor private constructor(mutability: Mutability)
 		//The interval is mutable and large enough to warrant changing in place.
 		val newStart: A_Number = self[END]
 		val newEnd: A_Number = self[START]
-		val newDelta =
-			self[DELTA].timesCanDestroy(fromInt(-1), true)
+		val newDelta = self[DELTA].timesCanDestroy(fromInt(-1), true)
 		self[START] = newStart
 		self[END] = newEnd
 		self[DELTA] = newDelta

--- a/avail/src/main/kotlin/avail/descriptor/tuples/NybbleTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/NybbleTupleDescriptor.kt
@@ -594,8 +594,9 @@ class NybbleTupleDescriptor private constructor(
 		{
 			super.o_TupleReverse(self)
 		}
-		else generateNybbleTupleFrom(size)
-			{ getNybble(self, size + 1 - it).toInt() }
+		else generateNybbleTupleFrom(size) {
+			getNybble(self, size + 1 - it).toInt()
+		}
 	}
 
 	override fun o_TupleSize(self: AvailObject): Int =

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ObjectTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ObjectTupleDescriptor.kt
@@ -489,8 +489,9 @@ class ObjectTupleDescriptor private constructor(mutability: Mutability)
 		}
 		else
 		{
-			generateReversedFrom(size)
-				{ self[TUPLE_AT_, size + 1 - it] }
+			generateReversedFrom(size) {
+				self[TUPLE_AT_, size + 1 - it]
+			}
 		}
 	}
 

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ReverseTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ReverseTupleDescriptor.kt
@@ -292,7 +292,7 @@ class ReverseTupleDescriptor private constructor(mutability: Mutability)
 			{
 				result.makeSubobjectsImmutable()
 			}
-			result[HASH_OR_ZERO] = 0 
+			result[HASH_OR_ZERO] = 0
 			return result
 		}
 		val subrangeOnOrigin =
@@ -402,11 +402,9 @@ class ReverseTupleDescriptor private constructor(mutability: Mutability)
 		return self[ORIGIN_TUPLE].tupleLongAt(reverseIndex)
 	}
 
-	override fun o_TupleReverse(self: AvailObject): A_Tuple =
-		self[ORIGIN_TUPLE]
+	override fun o_TupleReverse(self: AvailObject): A_Tuple = self[ORIGIN_TUPLE]
 
-	override fun o_TupleSize(self: AvailObject): Int =
-		self[SIZE]
+	override fun o_TupleSize(self: AvailObject): Int = self[SIZE]
 
 	override fun mutable(): ReverseTupleDescriptor = mutable
 

--- a/avail/src/main/kotlin/avail/descriptor/tuples/SmallIntegerIntervalTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/SmallIntegerIntervalTupleDescriptor.kt
@@ -176,7 +176,7 @@ constructor(
 				{
 					self[END] = newElementValue
 					self[SIZE] = originalSize + 1
-					self[HASH_OR_ZERO] = 0 
+					self[HASH_OR_ZERO] = 0
 					return self
 				}
 				// Create another small integer interval.
@@ -537,8 +537,7 @@ constructor(
 		// If tuple is small enough or is immutable, create a new interval.
 		if (!isMutable)
 		{
-			return createSmallInterval(
-				self[END], self[START], newDelta)
+			return createSmallInterval(self[END], self[START], newDelta)
 		}
 
 		//The interval is mutable and large enough to warrant changing in place.

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
@@ -349,6 +349,12 @@ protected constructor(
 		self: AvailObject,
 		aString: A_String): Boolean = o_EqualsAnyTuple(self, aString)
 
+	// Default to generic tuple comparison.
+	override fun o_EqualsTwentyOneBitString(
+		self: AvailObject,
+		aTwentyOneBitString: A_String
+	): Boolean = o_EqualsAnyTuple(self, aTwentyOneBitString)
+
 	// Given two objects that are known to be equal, is the first one in a
 	// better form (more compact, more efficient, older generation) than
 	// the second one?
@@ -559,26 +565,42 @@ protected constructor(
 		startIndex1: Int,
 		endIndex1: Int,
 		anObjectTuple: A_Tuple,
-		startIndex2: Int): Boolean =
-			o_CompareFromToWithAnyTupleStartingAt(
-				self,
-				startIndex1,
-				endIndex1,
-				anObjectTuple,
-				startIndex2)
+		startIndex2: Int
+	): Boolean =
+		o_CompareFromToWithAnyTupleStartingAt(
+			self,
+			startIndex1,
+			endIndex1,
+			anObjectTuple,
+			startIndex2)
 
 	override fun o_CompareFromToWithTwoByteStringStartingAt(
 		self: AvailObject,
 		startIndex1: Int,
 		endIndex1: Int,
 		aTwoByteString: A_String,
-		startIndex2: Int): Boolean =
-			o_CompareFromToWithAnyTupleStartingAt(
-				self,
-				startIndex1,
-				endIndex1,
-				aTwoByteString,
-				startIndex2)
+		startIndex2: Int
+	): Boolean =
+		o_CompareFromToWithAnyTupleStartingAt(
+			self,
+			startIndex1,
+			endIndex1,
+			aTwoByteString,
+			startIndex2)
+
+	override fun o_CompareFromToWithTwentyOneBitStringStartingAt(
+		self: AvailObject,
+		startIndex1: Int,
+		endIndex1: Int,
+		aTwentyOneBitString: A_String,
+		startIndex2: Int
+	): Boolean =
+		o_CompareFromToWithAnyTupleStartingAt(
+			self,
+			startIndex1,
+			endIndex1,
+			aTwentyOneBitString,
+			startIndex2)
 
 	override fun o_ConcatenateTuplesCanDestroy(
 		self: AvailObject,
@@ -642,6 +664,7 @@ protected constructor(
 			}
 			return self
 		}
+		if (!canDestroy && isMutable) self.makeImmutable()
 		return SubrangeTupleDescriptor.createSubrange(self, start, size)
 	}
 
@@ -759,8 +782,8 @@ protected constructor(
 			}
 			return when
 			{
-				maxCodePoint <= 255 -> SerializerOperation.BYTE_STRING
-				maxCodePoint <= 65535 -> SerializerOperation.SHORT_STRING
+				maxCodePoint <= 0xFF -> SerializerOperation.BYTE_STRING
+				maxCodePoint <= 0xFFFF -> SerializerOperation.SHORT_STRING
 				else -> SerializerOperation.ARBITRARY_STRING
 			}
 		}
@@ -788,8 +811,8 @@ protected constructor(
 			}
 			return when
 			{
-				maxInteger <= 15 -> SerializerOperation.NYBBLE_TUPLE
-				maxInteger <= 255 -> SerializerOperation.BYTE_TUPLE
+				maxInteger <= 0xF -> SerializerOperation.NYBBLE_TUPLE
+				maxInteger <= 0xFF -> SerializerOperation.BYTE_TUPLE
 				else -> SerializerOperation.INT_TUPLE
 			}
 		}

--- a/avail/src/main/kotlin/avail/interpreter/effects/LoadingEffectToRunPrimitive.kt
+++ b/avail/src/main/kotlin/avail/interpreter/effects/LoadingEffectToRunPrimitive.kt
@@ -35,6 +35,7 @@ package avail.interpreter.effects
 import avail.descriptor.bundles.A_Bundle
 import avail.descriptor.bundles.A_Bundle.Companion.bundleMethod
 import avail.descriptor.methods.A_Method.Companion.numArgs
+import avail.descriptor.methods.MethodDescriptor.SpecialMethodAtom
 import avail.descriptor.representation.A_BasicObject
 import avail.descriptor.types.PrimitiveTypeDescriptor.Types.TOP
 import avail.interpreter.levelOne.L1InstructionWriter
@@ -44,21 +45,21 @@ import avail.interpreter.levelOne.L1Operation
  * A `LoadingEffectToRunPrimitive` summarizes the execution of some
  * primitive, with literal arguments.
  *
- * @property primitiveBundle
- *   The primitive to run.
+ * @property specialMethodAtom
+ *   The [SpecialMethodAtom] for the primitive to run.
  * @author Mark van Gulik &lt;mark@availlang.org&gt;
  *
  * @constructor
  *
  * Construct a new `LoadingEffectToRunPrimitive`.
  *
- * @param primitiveBundle
- *   The primitive [A_Bundle] to invoke.
+ * @param specialMethodAtom
+ *   The [SpecialMethodAtom] enum value whose [A_Bundle] to invoke.
  * @param arguments
  *   The argument values for the primitive.
  */
 internal class LoadingEffectToRunPrimitive constructor(
-	private val primitiveBundle: A_Bundle,
+	private val specialMethodAtom: SpecialMethodAtom,
 	vararg arguments: A_BasicObject) : LoadingEffect()
 {
 	/** The array of arguments to pass to the primitive. */
@@ -66,7 +67,7 @@ internal class LoadingEffectToRunPrimitive constructor(
 
 	init
 	{
-		assert(primitiveBundle.bundleMethod.numArgs == arguments.size)
+		assert(specialMethodAtom.bundle.bundleMethod.numArgs == arguments.size)
 	}
 
 	override fun writeEffectTo(writer: L1InstructionWriter, startLine: Int)
@@ -82,7 +83,7 @@ internal class LoadingEffectToRunPrimitive constructor(
 		writer.write(
 			if (arguments.isEmpty()) startLine else 0,
 			L1Operation.L1_doCall,
-			writer.addLiteral(primitiveBundle),
+			writer.addLiteral(specialMethodAtom.bundle),
 			writer.addLiteral(TOP.o))
 	}
 }

--- a/avail/src/main/kotlin/avail/interpreter/execution/LexicalScanner.kt
+++ b/avail/src/main/kotlin/avail/interpreter/execution/LexicalScanner.kt
@@ -390,7 +390,7 @@ constructor(
 		// got a chance to run.
 		fibers.forEachIndexed { i, fiber ->
 			loader.runtime.runOutermostFunction(
-				fiber, undecidedLexers[i].lexerFilterFunction, argsList)
+				fiber, undecidedLexers[i].lexerFilterFunction, argsList, true)
 		}
 	}
 }

--- a/avail/src/main/kotlin/avail/interpreter/primitive/atoms/P_AtomRemoveProperty.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/atoms/P_AtomRemoveProperty.kt
@@ -79,9 +79,7 @@ object P_AtomRemoveProperty : Primitive(
 		atom.setAtomProperty(propertyKey, nil)
 		interpreter.availLoaderOrNull()?.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.ATOM_REMOVE_PROPERTY.bundle,
-				atom,
-				propertyKey))
+				SpecialMethodAtom.ATOM_REMOVE_PROPERTY, atom, propertyKey))
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/atoms/P_AtomSetProperty.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/atoms/P_AtomSetProperty.kt
@@ -75,7 +75,7 @@ object P_AtomSetProperty : Primitive(
 		atom.setAtomProperty(propertyKey, propertyValue)
 		interpreter.availLoaderOrNull()?.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.ATOM_PROPERTY.bundle,
+				SpecialMethodAtom.ATOM_PROPERTY,
 				atom,
 				propertyKey,
 				propertyValue))

--- a/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_DelayedFork.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_DelayedFork.kt
@@ -139,8 +139,8 @@ object P_DelayedFork : Primitive(
 		val runtime = interpreter.runtime
 		when
 		{
-			sleepMillis.equalsInt(0) ->
-				runtime.runOutermostFunction(newFiber, function, callArgs)
+			sleepMillis.equalsInt(0) -> runtime.runOutermostFunction(
+				newFiber, function, callArgs, false)
 			sleepMillis.isLong ->
 			{
 				runtime.timer.schedule(
@@ -149,7 +149,7 @@ object P_DelayedFork : Primitive(
 						override fun run()
 						{
 							runtime.runOutermostFunction(
-								newFiber, function, callArgs)
+								newFiber, function, callArgs, false)
 						}
 					},
 					sleepMillis.extractLong)

--- a/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_DelayedForkOrphan.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_DelayedForkOrphan.kt
@@ -145,7 +145,7 @@ object P_DelayedForkOrphan : Primitive(
 		val runtime = interpreter.runtime
 		if (sleepMillis.equalsInt(0))
 		{
-			runtime.runOutermostFunction(orphan, function, callArgs)
+			runtime.runOutermostFunction(orphan, function, callArgs, false)
 		}
 		else
 		{
@@ -156,7 +156,8 @@ object P_DelayedForkOrphan : Primitive(
 					{
 						// Don't check for the termination requested interrupt
 						// here, since no fiber could have signaled it.
-						runtime.runOutermostFunction(orphan, function, callArgs)
+						runtime.runOutermostFunction(
+							orphan, function, callArgs, false)
 					}
 				},
 				sleepMillis.extractLong)

--- a/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_Fork.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_Fork.kt
@@ -124,7 +124,8 @@ object P_Fork : Primitive(
 		// Schedule the fiber to run the specified function. Share the fiber,
 		// since it will be visible to the caller.
 		newFiber.makeShared()
-		interpreter.runtime.runOutermostFunction(newFiber, function, callArgs)
+		interpreter.runtime.runOutermostFunction(
+			newFiber, function, callArgs, false)
 		return interpreter.primitiveSuccess(newFiber)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_ForkOrphan.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/fibers/P_ForkOrphan.kt
@@ -122,7 +122,8 @@ object P_ForkOrphan : Primitive(
 		orphan.heritableFiberGlobals =
 			current.heritableFiberGlobals.makeShared()
 		// Schedule the fiber to run the specified function.
-		interpreter.runtime.runOutermostFunction(orphan, function, callArgs)
+		interpreter.runtime.runOutermostFunction(
+			orphan, function, callArgs, false)
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/files/P_CreateDirectory.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/files/P_CreateDirectory.kt
@@ -146,7 +146,10 @@ object P_CreateDirectory : Primitive(5, CanInline, HasSideEffect)
 				catch (e: FileAlreadyExistsException)
 				{
 					runtime.runOutermostFunction(
-						newFiber, fail, listOf(E_FILE_EXISTS.numericCode()))
+						newFiber,
+						fail,
+						listOf(E_FILE_EXISTS.numericCode()),
+						false)
 					return@Runnable
 				}
 				catch (e: SecurityException)
@@ -154,7 +157,8 @@ object P_CreateDirectory : Primitive(5, CanInline, HasSideEffect)
 					runtime.runOutermostFunction(
 						newFiber,
 						fail,
-						listOf(E_PERMISSION_DENIED.numericCode()))
+						listOf(E_PERMISSION_DENIED.numericCode()),
+						false)
 					return@Runnable
 				}
 				catch (e: AccessDeniedException)
@@ -162,16 +166,18 @@ object P_CreateDirectory : Primitive(5, CanInline, HasSideEffect)
 					runtime.runOutermostFunction(
 						newFiber,
 						fail,
-						listOf(E_PERMISSION_DENIED.numericCode()))
+						listOf(E_PERMISSION_DENIED.numericCode()),
+						false)
 					return@Runnable
 				}
 				catch (e: IOException)
 				{
 					runtime.runOutermostFunction(
-						newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+						newFiber, fail, listOf(E_IO_ERROR.numericCode()), false)
 					return@Runnable
 				}
-				runtime.runOutermostFunction(newFiber, succeed, emptyList())
+				runtime.runOutermostFunction(
+					newFiber, succeed, emptyList(), false)
 			})
 		return interpreter.primitiveSuccess(newFiber)
 	}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileRead.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileRead.kt
@@ -269,7 +269,7 @@ object P_FileRead : Primitive(6, CanInline, HasSideEffect)
 			val buffersTuple = tupleFromList(buffers as List<A_BasicObject>)
 			val concatenated = buffersTuple.concatenateTuplesCanDestroy(false)
 			runtime.runOutermostFunction(
-				newFiber, succeed, listOf(concatenated))
+				newFiber, succeed, listOf(concatenated), false)
 			return interpreter.primitiveSuccess(newFiber)
 		}
 		// We began with buffer misses, and we can figure out how many...
@@ -324,12 +324,12 @@ object P_FileRead : Primitive(6, CanInline, HasSideEffect)
 					}
 				}
 				runtime.runOutermostFunction(
-					newFiber, succeed, listOf(bytesTuple))
+					newFiber, succeed, listOf(bytesTuple), false)
 			},
 			// failed
 			{
 				runtime.runOutermostFunction(
-					newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+					newFiber, fail, listOf(E_IO_ERROR.numericCode()), false)
 			}
 		).guardedDo {
 			fileChannel.read(buffer, oneBasedPositionLong - 1, Unit, handler)

--- a/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileRename.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileRename.kt
@@ -151,11 +151,11 @@ object P_FileRename : Primitive(6, CanInline, HasSideEffect)
 					else -> throw e
 				}
 				runtime.runOutermostFunction(
-					newFiber, fail, listOf(errorCode.numericCode()))
+					newFiber, fail, listOf(errorCode.numericCode()), false)
 				return@executeFileTask
 			}
 
-			runtime.runOutermostFunction(newFiber, succeed, emptyList())
+			runtime.runOutermostFunction(newFiber, succeed, emptyList(), false)
 		}
 		return interpreter.primitiveSuccess(newFiber)
 	}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileSync.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileSync.kt
@@ -138,10 +138,11 @@ object P_FileSync : Primitive(4, CanInline, HasSideEffect)
 				catch (e: IOException)
 				{
 					runtime.runOutermostFunction(
-						newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+						newFiber, fail, listOf(E_IO_ERROR.numericCode()), false)
 					return@Runnable
 				}
-				runtime.runOutermostFunction(newFiber, succeed, emptyList())
+				runtime.runOutermostFunction(
+					newFiber, succeed, emptyList(), false)
 			})
 		return interpreter.primitiveSuccess(newFiber)
 	}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileTruncate.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileTruncate.kt
@@ -144,11 +144,12 @@ object P_FileTruncate : Primitive(5, CanInline, HasSideEffect)
 				catch (e: IOException)
 				{
 					runtime.runOutermostFunction(
-						newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+						newFiber, fail, listOf(E_IO_ERROR.numericCode()), false)
 					return@Runnable
 				}
 
-				runtime.runOutermostFunction(newFiber, succeed, emptyList())
+				runtime.runOutermostFunction(
+					newFiber, succeed, emptyList(), false)
 			})
 
 		return interpreter.primitiveSuccess(newFiber)

--- a/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileWrite.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/files/P_FileWrite.kt
@@ -274,7 +274,10 @@ object P_FileWrite : Primitive(6, CanInline, HasSideEffect)
 							}
 						}
 						runtime.runOutermostFunction(
-							newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+							newFiber,
+							fail,
+							listOf(E_IO_ERROR.numericCode()),
+							false)
 					}
 				).guardedDo {
 					fileChannel.write(
@@ -360,7 +363,8 @@ object P_FileWrite : Primitive(6, CanInline, HasSideEffect)
 					offsetInBuffer = 1
 				}
 				assert(subscriptInTuple == totalBytes + 1)
-				runtime.runOutermostFunction(newFiber, succeed, emptyList())
+				runtime.runOutermostFunction(
+					newFiber, succeed, emptyList(), false)
 			}
 		}
 		return interpreter.primitiveSuccess(newFiber)

--- a/avail/src/main/kotlin/avail/interpreter/primitive/methods/P_Alias.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/methods/P_Alias.kt
@@ -117,7 +117,7 @@ object P_Alias : Primitive(2, CanInline, HasSideEffect)
 			val method = oldBundle.bundleMethod
 			loader.recordEarlyEffect(
 				LoadingEffectToRunPrimitive(
-					SpecialMethodAtom.ALIAS.bundle, newString, oldAtom))
+					SpecialMethodAtom.ALIAS, newString, oldAtom))
 			newBundle(newAtom, method, MessageSplitter.split(newString))
 		}
 		catch (e: MalformedMessageException)

--- a/avail/src/main/kotlin/avail/interpreter/primitive/methods/P_SimpleLexerDefinitionForAtom.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/methods/P_SimpleLexerDefinitionForAtom.kt
@@ -124,11 +124,9 @@ object P_SimpleLexerDefinitionForAtom : Primitive(4, CanSuspend, Unknown)
 				stringFrom("Filter for lexer ${atom.atomName}")
 			bodyFunction.code().methodName =
 				stringFrom("Body for lexer ${atom.atomName}")
-			// Updating the lexical scanner is cheap enough that we do it even
-			// when we're loading, not just compiling.  This allows us to parse
-			// and run entry points in the scope of the module, without having
-			// to generate the lexicalScanner for a module that has already been
-			// closed (ModuleDescriptor.State.Loaded).
+			// Only bother to update the lexical scanner during compilation, not
+			// during loading.  The parseCommand() operation used by Anvil can
+			// rebuild any necessary LexicalScanners in a split-second.
 			if (loader.phase == EXECUTING_FOR_COMPILE)
 			{
 				loader.lexicalScanner!!.addLexer(lexer)
@@ -147,7 +145,7 @@ object P_SimpleLexerDefinitionForAtom : Primitive(4, CanSuspend, Unknown)
 			}
 			loader.recordEffect(
 				LoadingEffectToRunPrimitive(
-					SpecialMethodAtom.LEXER_DEFINER.bundle,
+					SpecialMethodAtom.LEXER_DEFINER,
 					atom,
 					filterFunction,
 					bodyFunction,

--- a/avail/src/main/kotlin/avail/interpreter/primitive/methods/P_SimpleMethodStabilityHelper.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/methods/P_SimpleMethodStabilityHelper.kt
@@ -181,7 +181,7 @@ object P_SimpleMethodStabilityHelper : Primitive(
 							afterEach(null)
 						})
 					runtime.runOutermostFunction(
-						fiber, functionToInvoke, combination)
+						fiber, functionToInvoke, combination, false)
 				},
 				then = { list ->
 					if (list.any { it === null })

--- a/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_AddPostLoadFunction.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_AddPostLoadFunction.kt
@@ -34,6 +34,7 @@ package avail.interpreter.primitive.modules
 
 import avail.descriptor.fiber.A_Fiber.Companion.availLoader
 import avail.descriptor.functions.A_Function
+import avail.descriptor.methods.MethodDescriptor.SpecialMethodAtom
 import avail.descriptor.module.A_Module.Companion.addPostLoadFunction
 import avail.descriptor.representation.NilDescriptor.Companion.nil
 import avail.descriptor.sets.SetDescriptor.Companion.set
@@ -48,6 +49,7 @@ import avail.interpreter.Primitive
 import avail.interpreter.Primitive.Flag.CanInline
 import avail.interpreter.Primitive.Flag.HasSideEffect
 import avail.interpreter.Primitive.Flag.WritesToHiddenGlobalState
+import avail.interpreter.effects.LoadingEffectToRunPrimitive
 import avail.interpreter.execution.Interpreter
 
 /**
@@ -68,6 +70,10 @@ object P_AddPostLoadFunction : Primitive(
 			?: return interpreter.primitiveFailure(E_LOADING_IS_OVER)
 		val module = loader.module
 		module.addPostLoadFunction(postLoadFunction)
+		loader.recordEffect(
+			LoadingEffectToRunPrimitive(
+				SpecialMethodAtom.ADD_POSTLOAD_FUNCTION, postLoadFunction)
+		)
 		// No need to record a loader effect here.  The eventual execution of
 		// the function will be sufficient to capture side effects for the fast
 		// loader to replay.

--- a/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_AddPostLoadFunction.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_AddPostLoadFunction.kt
@@ -1,0 +1,82 @@
+/*
+ * P_AddPostLoadFunction.kt
+ * Copyright © 1993-2023, The Avail Foundation, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of the contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package avail.interpreter.primitive.modules
+
+import avail.descriptor.fiber.A_Fiber.Companion.availLoader
+import avail.descriptor.functions.A_Function
+import avail.descriptor.module.A_Module.Companion.addPostLoadFunction
+import avail.descriptor.representation.NilDescriptor.Companion.nil
+import avail.descriptor.sets.SetDescriptor.Companion.set
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.types.A_Type
+import avail.descriptor.types.AbstractEnumerationTypeDescriptor.Companion.enumerationWith
+import avail.descriptor.types.FunctionTypeDescriptor.Companion.functionType
+import avail.descriptor.types.FunctionTypeDescriptor.Companion.functionTypeReturning
+import avail.descriptor.types.PrimitiveTypeDescriptor.Types.TOP
+import avail.exceptions.AvailErrorCode.E_LOADING_IS_OVER
+import avail.interpreter.Primitive
+import avail.interpreter.Primitive.Flag.CanInline
+import avail.interpreter.Primitive.Flag.HasSideEffect
+import avail.interpreter.Primitive.Flag.WritesToHiddenGlobalState
+import avail.interpreter.execution.Interpreter
+
+/**
+* **Primitive:** Add the specified [post-load&#32;function][A_Function] to the
+ * [current][Interpreter.module] module.
+ *
+ * @author Mark van Gulik &lt;mark@availlang.org&gt;
+ */
+@Suppress("unused")
+object P_AddPostLoadFunction : Primitive(
+	1, CanInline, HasSideEffect, WritesToHiddenGlobalState)
+{
+	override fun attempt(interpreter: Interpreter): Result
+	{
+		interpreter.checkArgumentCount(1)
+		val postLoadFunction = interpreter.argument(0)
+		val loader = interpreter.fiber().availLoader
+			?: return interpreter.primitiveFailure(E_LOADING_IS_OVER)
+		val module = loader.module
+		module.addPostLoadFunction(postLoadFunction)
+		// No need to record a loader effect here.  The eventual execution of
+		// the function will be sufficient to capture side effects for the fast
+		// loader to replay.
+		return interpreter.primitiveSuccess(nil)
+	}
+
+	override fun privateBlockTypeRestriction(): A_Type =
+		functionType(tuple(functionTypeReturning(TOP.o)), TOP.o)
+
+	override fun privateFailureVariableType(): A_Type =
+		enumerationWith(set(E_LOADING_IS_OVER))
+}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_AddUnloadFunction.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_AddUnloadFunction.kt
@@ -72,7 +72,7 @@ object P_AddUnloadFunction : Primitive(
 		module.addUnloadFunction(unloadFunction)
 		loader.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.ADD_UNLOADER.bundle, unloadFunction))
+				SpecialMethodAtom.ADD_UNLOAD_FUNCTION, unloadFunction))
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_PublishName.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/modules/P_PublishName.kt
@@ -96,9 +96,7 @@ object P_PublishName : Primitive(
 			{
 				// Record the publication.
 				loader.recordEffect(
-					LoadingEffectToRunPrimitive(
-						PUBLISH_NEW_NAME.bundle,
-						name))
+					LoadingEffectToRunPrimitive(PUBLISH_NEW_NAME, name))
 			}
 			interpreter.primitiveSuccess(nil)
 		}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/objects/P_RecordNewTypeName.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/objects/P_RecordNewTypeName.kt
@@ -68,7 +68,7 @@ object P_RecordNewTypeName : Primitive(2, CanInline, CannotFail, HasSideEffect)
 		setNameForType(userType, name, false)
 		interpreter.availLoaderOrNull()?.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.RECORD_TYPE_NAME.bundle, userType, name))
+				SpecialMethodAtom.RECORD_TYPE_NAME, userType, name))
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/phrases/P_CreateRestrictedSendExpression.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/phrases/P_CreateRestrictedSendExpression.kt
@@ -270,7 +270,11 @@ object P_CreateRestrictedSendExpression : Primitive(3, CanSuspend, Unknown)
 							after()
 						})
 					runtime.runOutermostFunction(
-						forkedFiber, restriction.function(), argTypesList)				},
+						forkedFiber,
+						restriction.function(),
+						argTypesList,
+						false)
+				},
 				then = {
 					when
 					{

--- a/avail/src/main/kotlin/avail/interpreter/primitive/processes/P_ExecuteAttachedExternalProcess.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/processes/P_ExecuteAttachedExternalProcess.kt
@@ -162,7 +162,7 @@ object P_ExecuteAttachedExternalProcess : Primitive(6, CanInline, HasSideEffect)
 			current.heritableFiberGlobals.makeShared()
 		newFiber.makeShared()
 		toRun.makeShared()
-		runtime.runOutermostFunction(newFiber, toRun, args)
+		runtime.runOutermostFunction(newFiber, toRun, args, false)
 		return interpreter.primitiveSuccess(newFiber)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/rawfunctions/P_SetCompiledCodeName.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/rawfunctions/P_SetCompiledCodeName.kt
@@ -68,9 +68,7 @@ object P_SetCompiledCodeName : Primitive(
 		code.methodName = name
 		interpreter.availLoaderOrNull()?.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.SET_COMPILED_CODE_NAME.bundle,
-				code,
-				name))
+				SpecialMethodAtom.SET_COMPILED_CODE_NAME, code, name))
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_ServerSocketAccept.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_ServerSocketAccept.kt
@@ -145,11 +145,13 @@ object P_ServerSocketAccept : Primitive(5, CanInline, HasSideEffect)
 						val newPojo = identityPojo(value)
 						newHandle.setAtomProperty(SOCKET_KEY.atom, newPojo)
 						runtime.runOutermostFunction(
-							newFiber, succeed, listOf<A_Atom>(newHandle))
+							newFiber, succeed, listOf<A_Atom>(newHandle), false)
 					},
 					{
 						runtime.runOutermostFunction(
-							newFiber,fail, listOf(E_IO_ERROR.numericCode()))
+							newFiber,fail,
+							listOf(E_IO_ERROR.numericCode()),
+							false)
 					}))
 			interpreter.primitiveSuccess(newFiber)
 		}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketIPv4Connect.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketIPv4Connect.kt
@@ -167,11 +167,14 @@ object P_SocketIPv4Connect : Primitive(6, CanInline, HasSideEffect)
 				SimpleCompletionHandler(
 					{
 						runtime.runOutermostFunction(
-							newFiber, succeed, emptyList())
+							newFiber, succeed, emptyList(), false)
 					},
 					{
 						runtime.runOutermostFunction(
-							newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+							newFiber,
+							fail,
+							listOf(E_IO_ERROR.numericCode()),
+							false)
 					}))
 			interpreter.primitiveSuccess(newFiber)
 		}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketIPv6Connect.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketIPv6Connect.kt
@@ -167,11 +167,14 @@ object P_SocketIPv6Connect : Primitive(6, CanInline, HasSideEffect)
 				SimpleCompletionHandler(
 					{
 						runtime.runOutermostFunction(
-							newFiber, succeed, emptyList())
+							newFiber, succeed, emptyList(), false)
 					},
 					{
 						runtime.runOutermostFunction(
-							newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+							newFiber,
+							fail,
+							listOf(E_IO_ERROR.numericCode()),
+							false)
 					}))
 			interpreter.primitiveSuccess(newFiber)
 		}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketRead.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketRead.kt
@@ -149,13 +149,15 @@ object P_SocketRead : Primitive(5, CanInline, HasSideEffect)
 							succeed,
 							listOf(
 								tupleForByteBuffer(buffer),
-								objectFromBoolean(value == -1)))
+								objectFromBoolean(value == -1)),
+							false)
 					},
 					{
 						runtime.runOutermostFunction(
 							newFiber,
 							fail,
-							listOf(E_IO_ERROR.numericCode()))
+							listOf(E_IO_ERROR.numericCode()),
+							false)
 					}))
 			interpreter.primitiveSuccess(newFiber)
 		}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketWrite.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/sockets/P_SocketWrite.kt
@@ -157,12 +157,15 @@ object P_SocketWrite : Primitive(5, CanInline, HasSideEffect)
 						{
 							// Done all writing.  Report success.
 							runtime.runOutermostFunction(
-								newFiber, succeed, emptyList())
+								newFiber, succeed, emptyList(), false)
 						}
 					},
 					{
 						runtime.runOutermostFunction(
-							newFiber, fail, listOf(E_IO_ERROR.numericCode()))
+							newFiber,
+							fail,
+							listOf(E_IO_ERROR.numericCode()),
+							false)
 					}))
 			interpreter.primitiveSuccess(newFiber)
 		}

--- a/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicAddToMap.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicAddToMap.kt
@@ -83,10 +83,7 @@ object P_AtomicAddToMap : Primitive(3, CanInline, HasSideEffect) {
 
 		interpreter.availLoaderOrNull()?.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.ADD_TO_MAP_VARIABLE.bundle,
-				variable,
-				key,
-				value))
+				SpecialMethodAtom.ADD_TO_MAP_VARIABLE, variable, key, value))
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicRemoveFromMap.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicRemoveFromMap.kt
@@ -83,9 +83,7 @@ object P_AtomicRemoveFromMap : Primitive(2, CanInline, HasSideEffect) {
 
 		interpreter.availLoaderOrNull()?.recordEffect(
 			LoadingEffectToRunPrimitive(
-				SpecialMethodAtom.REMOVE_FROM_MAP_VARIABLE.bundle,
-				variable,
-				key))
+				SpecialMethodAtom.REMOVE_FROM_MAP_VARIABLE, variable, key))
 		return interpreter.primitiveSuccess(nil)
 	}
 

--- a/avail/src/main/kotlin/avail/persistence/cache/Repository.kt
+++ b/avail/src/main/kotlin/avail/persistence/cache/Repository.kt
@@ -154,7 +154,7 @@ class Repository constructor(
 	 * @author Mark van Gulik &lt;mark@availlang.org&gt;
 	 */
 	private object IndexedRepositoryBuilder : IndexedFileBuilder(
-		"Avail compiled module repository V16")
+		"Avail compiled module repository V17")
 
 	/**
 	 * The [lock][ReentrantLock] responsible for guarding against unsafe

--- a/avail/src/main/resources/avail/tools/bootstrap/generated/ErrorCodeNames_en.properties
+++ b/avail/src/main/resources/avail/tools/bootstrap/generated/ErrorCodeNames_en.properties
@@ -33,7 +33,7 @@
 #
 # GENERATED FILE
 # * Generator: java.io.PrintWriter
-# * Last Generated: 8/20/23, 7:31 PM
+# * Last Generated: 8/25/23, 10:19 AM
 #
 # Property assignments, BUT NOT THE COPYRIGHT OR THIS NOTICE, may safely be
 # modified manually.

--- a/avail/src/main/resources/avail/tools/bootstrap/generated/PrimitiveNames_en.properties
+++ b/avail/src/main/resources/avail/tools/bootstrap/generated/PrimitiveNames_en.properties
@@ -33,7 +33,7 @@
 #
 # GENERATED FILE
 # * Generator: java.io.PrintWriter
-# * Last Generated: 8/20/23, 7:31 PM
+# * Last Generated: 8/25/23, 10:19 AM
 #
 # Property assignments, BUT NOT THE COPYRIGHT OR THIS NOTICE, may safely be
 # modified manually.
@@ -3680,6 +3680,7 @@ P_LinkPrimitives_comment=\
 \ * @raises "{6}"\n\
 \ * @raises "{7}"\n\
 \ * @raises "{8}"\n\
+\ * @raises "{9}"\n\
 \ */\n
 # CreateMap : _=1
 P_CreateMap=_→map
@@ -5139,6 +5140,21 @@ P_SimpleMethodDeclaration_comment=\
 \ * @raises "{27}"\n\
 \ * @raises "{28}"\n\
 \ * @raises "{29}"\n\
+\ */\n
+# AddPostLoadFunction : _=1
+P_AddPostLoadFunction=After the current module is loaded,⁇do_
+P_AddPostLoadFunction_1=aFunction
+P_AddPostLoadFunction_comment=\
+/**\n\
+\ * Register the given function for callback after the module undergoing\n\
+\ * compilation has been otherwise fully parsed and compiled.\n\
+\ *\n\
+\ * @category "Primitives"\n\
+\ * @method "{0}"\n\
+\ * @param "{1}" "{2}"\n\
+\ *        The post-load function.\n\
+\ * @returns "{3}"\n\
+\ * @raises "{4}"\n\
 \ */\n
 # AddUnloadFunction : _=1
 P_AddUnloadFunction=After the current module is unloaded,⁇do_

--- a/avail/src/main/resources/avail/tools/bootstrap/generated/SpecialObjectNames_en.properties
+++ b/avail/src/main/resources/avail/tools/bootstrap/generated/SpecialObjectNames_en.properties
@@ -33,7 +33,7 @@
 #
 # GENERATED FILE
 # * Generator: java.io.PrintWriter
-# * Last Generated: 8/20/23, 7:31 PM
+# * Last Generated: 8/25/23, 10:19 AM
 #
 # Property assignments, BUT NOT THE COPYRIGHT OR THIS NOTICE, may safely be
 # modified manually.

--- a/avail/src/test/kotlin/avail/test/CallbackTest.kt
+++ b/avail/src/test/kotlin/avail/test/CallbackTest.kt
@@ -214,7 +214,8 @@ class CallbackTest
 				divisionCallback(),
 				tuple(
 					fromInt(42),
-					fromInt(3))))
+					fromInt(3))),
+			false)
 		try
 		{
 			mailbox.take().run()


### PR DESCRIPTION
From commit comment:

Implemented TwentyOneBitString, to make file compilation much
faster.  This problem was exposed by Todd's use of blackboard
double-struck W, which is beyond U+FFFF.
- Introduced post-load blocks via
  "After the current module is loaded,⁇do_"
- Bumped repository version to V17 due to special atom changes,
  as well as COMPRESSED_ARBITRARY_CHARACTER_TUPLE serialization.
- For performance bump, runOutermostFunction() takes a Boolean
  indicating whether the VM has vetted that the arguments are
  suitable for the function's signature.
- When no debugger is applicable, rather than run the P_Invoke
  primitive with the function and its arguments, the function
  itself (with arguments) is launched as the outermost frame.
- Character set syntax (like ¢[A-Z0-9]) had a bug where an
  escape sequence like ¢[...\t...] would include both the tab
  and the letter t.
- Increased size (strong and soft) of MessageSplitter cache.

Addresses issue #279 and #174 