### PR TITLE
Avail debugger now has F8 step-over.

### DIFF
--- a/avail/src/main/kotlin/avail/AvailDebuggerModel.kt
+++ b/avail/src/main/kotlin/avail/AvailDebuggerModel.kt
@@ -35,17 +35,24 @@ package avail
 import avail.descriptor.atoms.AtomDescriptor.SpecialAtom.DONT_DEBUG_KEY
 import avail.descriptor.fiber.A_Fiber
 import avail.descriptor.fiber.A_Fiber.Companion.captureInDebugger
+import avail.descriptor.fiber.A_Fiber.Companion.continuation
 import avail.descriptor.fiber.A_Fiber.Companion.executionState
 import avail.descriptor.fiber.A_Fiber.Companion.fiberHelper
 import avail.descriptor.fiber.A_Fiber.Companion.heritableFiberGlobals
 import avail.descriptor.fiber.A_Fiber.Companion.releaseFromDebugger
-import avail.descriptor.fiber.FiberDescriptor
+import avail.descriptor.fiber.FiberDescriptor.Companion.debuggerPriority
 import avail.descriptor.fiber.FiberDescriptor.ExecutionState.PAUSED
 import avail.descriptor.fiber.FiberDescriptor.FiberKind
+import avail.descriptor.functions.A_Continuation
+import avail.descriptor.functions.A_Continuation.Companion.caller
+import avail.descriptor.functions.A_Continuation.Companion.function
+import avail.descriptor.functions.A_Function
 import avail.descriptor.maps.A_Map.Companion.hasKey
+import avail.descriptor.representation.NilDescriptor.Companion.nil
 import avail.performance.Statistic
 import avail.performance.StatisticReport
 import avail.utility.safeWrite
+import javax.swing.SwingUtilities
 
 /**
  * [AvailDebuggerModel] controls the execution of a set of fibers, allowing
@@ -82,32 +89,105 @@ class AvailDebuggerModel constructor (
 		runtime.newFiberHandlers[fiberKind]!!.get() === fiberCaptureFunction
 
 	/**
-	 * Allow the specified fiber to execute exactly one nybblecode.  Supersede
-	 * any existing run/step mode for this fiber.  We must be in a safe point to
-	 * change this mode.
+	 * Allow the specified fiber to run in some way until some condition is met.
+	 * Supersede any existing run/step mode for this fiber.  We must be in a
+	 * safe point to change this mode.
 	 */
-	fun singleStep(fiber: A_Fiber)
+	fun runFiberAction(
+		fiber: A_Fiber,
+		doAction: AvailDebuggerModel.(A_Fiber)->Unit)
 	{
-		runtime.assertInSafePoint()
-		runtime.runtimeLock.safeWrite {
-			fiber.lock {
-				fiber.fiberHelper.let { helper ->
+		runtime.whenSafePointDo(debuggerPriority) {
+			runtime.assertInSafePoint()
+			runtime.runtimeLock.safeWrite {
+				fiber.lock {
 					assert(fiber.fiberHelper.debugger.get() == this)
-					var allow = true
-					helper.debuggerRunCondition = {
-						allow.also { allow = false }
-					}
+					this.doAction(fiber)
+					runtime.resumeIfPausedByDebugger(fiber)
 				}
-				runtime.resumeIfPausedByDebugger(fiber)
 			}
 		}
 	}
 
-	//TODO Rework and wire in these actions.
-
-	fun stepOverThen()
+	/**
+	 * An action to execute exactly one L1 instruction, the smallest unit of
+	 * execution.
+	 */
+	fun doSingleStep(fiber: A_Fiber)
 	{
-		TODO("Not yet implemented")
+		var allow = true
+		fiber.fiberHelper.debuggerRunCondition = {
+			allow.also { allow = false }
+		}
+		fiber.fiberHelper.debuggerCanInvoke = false
+	}
+
+	/**
+	 * An action to execute at least one L1 instruction, stopping only when the
+	 * current frame is at the top of the stack again, or has been removed from
+	 * the stack through a return or other means.
+	 *
+	 * TODO - Intercept non-local control flow just *prior* to jumping past the
+	 *  frame.
+	 */
+	fun doStepOver(fiber: A_Fiber)
+	{
+		val initialContinuation: A_Continuation =
+			fiber.continuation.traversed().makeShared()
+		if (initialContinuation.isNil)
+		{
+			// This probably can't happen, but assume the fiber has ended.
+			return
+		}
+		val initialFunction: A_Function = initialContinuation.function()
+		// Note: initialCaller might be nil.
+		val initialCaller: A_Continuation =
+			initialContinuation.caller().traversed()
+
+		var firstPoll = true
+		fiber.fiberHelper.debuggerRunCondition = condition@ { interpreter ->
+			if (firstPoll)
+			{
+				firstPoll = false
+				return@condition true
+			}
+			if (!interpreter.callerIsReified())
+			{
+				// There are JVM frames, so we're still in the middle of some
+				// call and are simply running unrelated L1 code.
+				return@condition true
+			}
+			assert(interpreter.fiber().equals(fiber))
+			val initialCallerTraversed = initialCaller.traversed()
+			val currentCallerTraversed = interpreter.getReifiedContinuation()
+				?.traversed()?.makeShared() ?: nil
+			if (currentCallerTraversed.sameAddressAs(initialCallerTraversed)
+				&& interpreter.function!!.equals(initialFunction))
+			{
+				// If we're in "the same" function invocation as we started, the
+				// firstPoll logic above should have tripped on the first step,
+				// so assume we've made some progress, regardless of whether the
+				// pc is the same, has advanced, or has even retreated.
+				return@condition false
+			}
+			var c = currentCallerTraversed
+			while (c.notNil)
+			{
+				if (c.sameAddressAs(initialCallerTraversed))
+				{
+					// We're still within the scope of the original caller.
+					return@condition true
+				}
+				c = c.caller().traversed()
+			}
+			// The original continuation's caller wasn't found, or is actually
+			// nil.  Either way, treat it as a stop condition.
+			return@condition false
+		}
+		// Allow functions to be started or run to completion, as long as they
+		// don't escape the current function.  This keeps the stepping speed
+		// close to 100% within the debugger, while preserving verisimilitude.
+		fiber.fiberHelper.debuggerCanInvoke = true
 	}
 
 	fun stepOutThen()
@@ -145,7 +225,7 @@ class AvailDebuggerModel constructor (
 		// ancestor) indicated that this fiber should not itself be debugged.
 		if (!fiber.heritableFiberGlobals.hasKey(DONT_DEBUG_KEY.atom))
 		{
-			runtime.whenSafePointDo(FiberDescriptor.debuggerPriority) {
+			runtime.whenSafePointDo(debuggerPriority) {
 				runtime.runtimeLock.safeWrite {
 					debuggedFibers.removeIf {
 						it.executionState.indicatesTermination
@@ -154,7 +234,9 @@ class AvailDebuggerModel constructor (
 					{
 						fiber.captureInDebugger(this)
 						debuggedFibers.add(fiber)
-						whenAddedFiberActions.forEach { it(fiber) }
+						SwingUtilities.invokeLater {
+							whenAddedFiberActions.forEach { it(fiber) }
+						}
 					}
 				}
 			}
@@ -188,9 +270,11 @@ class AvailDebuggerModel constructor (
 	 */
 	fun justPaused(fiber: A_Fiber)
 	{
-		runtime.whenSafePointDo(FiberDescriptor.debuggerPriority) {
+		runtime.whenSafePointDo(debuggerPriority) {
 			runtime.runtimeLock.safeWrite {
-				whenPausedActions.forEach { it(fiber) }
+				SwingUtilities.invokeLater {
+					whenPausedActions.forEach { it(fiber) }
+				}
 			}
 		}
 	}
@@ -215,7 +299,7 @@ class AvailDebuggerModel constructor (
 		fibersProvider: () -> Collection<A_Fiber>,
 		then: () -> Unit)
 	{
-		runtime.whenSafePointDo(FiberDescriptor.debuggerPriority) {
+		runtime.whenSafePointDo(debuggerPriority) {
 			// Prevent other debuggers from accessing the set of fibers.
 			runtime.runtimeLock.safeWrite {
 				val newFibers = fibersProvider()
@@ -246,7 +330,7 @@ class AvailDebuggerModel constructor (
 	 */
 	fun releaseFibersThen(then: () -> Unit)
 	{
-		runtime.whenSafePointDo(FiberDescriptor.debuggerPriority) {
+		runtime.whenSafePointDo(debuggerPriority) {
 			runtime.runtimeLock.safeWrite {
 				// Release each fiber from this debugger, allowing it to run if
 				// it was runnable.

--- a/avail/src/main/kotlin/avail/anvil/debugger/AbstractDebuggerAction.kt
+++ b/avail/src/main/kotlin/avail/anvil/debugger/AbstractDebuggerAction.kt
@@ -34,6 +34,7 @@ package avail.anvil.debugger
 
 import avail.anvil.actions.AbstractWorkbenchAction
 import avail.anvil.shortcuts.AvailDebuggerShortcut
+import javax.swing.Action
 
 /**
  * An [AbstractDebuggerAction] is attached to an [AvailDebugger], and
@@ -55,9 +56,18 @@ abstract class AbstractDebuggerAction(
 	@Suppress("MemberVisibilityCanBePrivate")
 	val debugger: AvailDebugger,
 	name: String,
+	shortDescription: String? = null,
 	shortcut: AvailDebuggerShortcut? = null)
 : AbstractWorkbenchAction(
 	debugger.workbench,
 	name,
 	shortcut,
 	debugger.rootPane)
+{
+	init
+	{
+		shortDescription?.let {
+			putValue(Action.SHORT_DESCRIPTION, it)
+		}
+	}
+}

--- a/avail/src/main/kotlin/avail/anvil/shortcuts/AvailDebuggerShortcuts.kt
+++ b/avail/src/main/kotlin/avail/anvil/shortcuts/AvailDebuggerShortcuts.kt
@@ -64,7 +64,7 @@ sealed class AvailDebuggerShortcut constructor(
  *
  * @author Richard Arriaga
  */
-object StepIntoShortcut: AvailDebuggerShortcut(KeyCode.VK_F7.with())
+data object StepIntoShortcut: AvailDebuggerShortcut(KeyCode.VK_F7.with())
 {
 	override val actionMapKey: String = "step-into"
 	override val description: String =
@@ -76,7 +76,7 @@ object StepIntoShortcut: AvailDebuggerShortcut(KeyCode.VK_F7.with())
  *
  * @author Richard Arriaga
  */
-object StepOverShortcut: AvailDebuggerShortcut(KeyCode.VK_F8.with())
+data object StepOverShortcut: AvailDebuggerShortcut(KeyCode.VK_F8.with())
 {
 	override val actionMapKey: String = "step-over"
 	override val description: String = "Step Over Operation"
@@ -87,7 +87,7 @@ object StepOverShortcut: AvailDebuggerShortcut(KeyCode.VK_F8.with())
  *
  * @author Richard Arriaga
  */
-object StepOutShortcut: AvailDebuggerShortcut(KeyCode.VK_F8.with(SHIFT))
+data object StepOutShortcut: AvailDebuggerShortcut(KeyCode.VK_F8.with(SHIFT))
 {
 	override val actionMapKey: String = "step-out"
 	override val description: String = "Step Out of Current Operation"
@@ -98,7 +98,7 @@ object StepOutShortcut: AvailDebuggerShortcut(KeyCode.VK_F8.with(SHIFT))
  *
  * @author Richard Arriaga
  */
-object ResumeActionShortcut
+data object ResumeActionShortcut
 	: AvailDebuggerShortcut(KeyCode.VK_R.with(menuShortcutKeyMaskEx))
 {
 	override val actionMapKey: String = "resume"

--- a/avail/src/main/kotlin/avail/builder/BuildLoader.kt
+++ b/avail/src/main/kotlin/avail/builder/BuildLoader.kt
@@ -43,9 +43,11 @@ import avail.compiler.problems.Problem
 import avail.compiler.problems.ProblemHandler
 import avail.compiler.problems.ProblemType.EXECUTION
 import avail.descriptor.fiber.A_Fiber.Companion.fiberHelper
+import avail.descriptor.fiber.A_Fiber.Companion.setGeneralFlag
 import avail.descriptor.fiber.A_Fiber.Companion.setSuccessAndFailure
 import avail.descriptor.fiber.FiberDescriptor.Companion.loaderPriority
 import avail.descriptor.fiber.FiberDescriptor.Companion.newLoaderFiber
+import avail.descriptor.fiber.FiberDescriptor.GeneralFlag.IS_RUNNING_TOP_STATEMENT
 import avail.descriptor.functions.A_Function
 import avail.descriptor.functions.A_RawFunction.Companion.codeStartingLineNumber
 import avail.descriptor.functions.A_RawFunction.Companion.methodName
@@ -441,6 +443,7 @@ internal class BuildLoader constructor(
 							code.module.shortModuleNameNative,
 							code.codeStartingLineNumber)
 					}
+					fiber.setGeneralFlag(IS_RUNNING_TOP_STATEMENT)
 					val before = fiber.fiberHelper.fiberTime()
 					fiber.setSuccessAndFailure(
 						onSuccess = {

--- a/avail/src/main/kotlin/avail/descriptor/fiber/FiberDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/fiber/FiberDescriptor.kt
@@ -371,12 +371,28 @@ class FiberDescriptor private constructor(
 		val debugger = AtomicReference<AvailDebuggerModel?>(null)
 
 		/**
-		 * A function which checks whether the given fiber should run, based on
-		 * what has been set up by the debugger.  This *must* be non-null
-		 * whenever the fiber is captured by a debugger.
+		 * A function which checks whether the fiber in the given interpreter
+		 * should run, based on what has been set up by the debugger.  This
+		 * *must* be non-null whenever the fiber is captured by a debugger.
 		 */
 		@Volatile
-		var debuggerRunCondition: ((A_Fiber)->Boolean)? = null
+		var debuggerRunCondition: ((Interpreter)->Boolean)? = null
+
+		/**
+		 * A function which checks whether the given fiber is allowed to perform
+		 * a function invocation without checking with the
+		 * [debuggerRunCondition].  Note that (1) both regular and non-local
+		 * control flow (e.g., exceptions, time slicing, backtracking) will exit
+		 * from the JVM stack frame that observed this to be true and invoked a
+		 * function, and (2) user-interface debugger control only happens during
+		 * safe points, so it's safe to temporarily replace the
+		 * [debuggerRunCondition] before the invocation and restore it after the
+		 * JVM-level call returns.
+		 *
+		 * This flag is only tested if the fiber is bound to a debugger.
+		 */
+		@Volatile
+		var debuggerCanInvoke: Boolean = true
 	}
 
 	/** The interpretation of the [FiberHelper]'s [flags][FiberHelper.flags]. */

--- a/avail/src/main/kotlin/avail/descriptor/functions/CompiledCodeDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/functions/CompiledCodeDescriptor.kt
@@ -504,7 +504,7 @@ open class CompiledCodeDescriptor protected constructor(
 		companion object
 		{
 			/** The offset into the array of the first nybblecode. */
-			const val baseIndexInArray = 2  // NYBBLECODE_.ordinal
+			val baseIndexInArray = NYBBLECODES_.ordinal
 
 			init
 			{

--- a/avail/src/main/kotlin/avail/descriptor/functions/ContinuationDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/functions/ContinuationDescriptor.kt
@@ -107,7 +107,6 @@ import avail.optimizer.jvm.CheckedMethod
 import avail.optimizer.jvm.CheckedMethod.Companion.staticMethod
 import avail.optimizer.jvm.ReferencedInGeneratedCode
 import avail.serialization.SerializerOperation
-import avail.utility.cast
 import avail.utility.ifZero
 import java.util.ArrayDeque
 import java.util.Deque
@@ -416,7 +415,7 @@ class ContinuationDescriptor private constructor(
 	// rare case that we do need it.
 	override fun o_Hash(self: AvailObject): Int =
 		self[HASH_OR_ZERO].ifZero {
-			val caller = self.caller().traversed().cast()!!
+			val caller = self.caller().traversed()
 			var callerHash = 0
 			if (caller.notNil && caller[HASH_OR_ZERO] == 0)
 			{
@@ -432,6 +431,8 @@ class ContinuationDescriptor private constructor(
 				while (ancestor.notNil && ancestor[HASH_OR_ZERO] == 0)
 				// Force the hashes to be computed, starting with the deepest.
 				chain.forEach { c ->
+					// Since these calls happen bottom-up, they won't have to
+					// recurse into their callers.
 					callerHash = c.hashCode()
 				}
 			}

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/L1InstructionStepper.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/L1InstructionStepper.kt
@@ -266,8 +266,7 @@ class L1InstructionStepper constructor(val interpreter: Interpreter)
 			// prior to installing the base frame hook.
 			if (debugger !== null)
 			{
-				val f = interpreter.fiber()
-				if (!interpreter.debuggerRunCondition!!(f))
+				if (!interpreter.debuggerRunCondition!!(interpreter))
 				{
 					// The debuggerRunCondition said we should pause now.
 					val mutableContinuation = createContinuationWithFrame(
@@ -288,6 +287,7 @@ class L1InstructionStepper constructor(val interpreter: Interpreter)
 					{
 						// Push the new continuation onto the reified stack.
 						interpreter.apply {
+							val f = fiber()
 							returnNow = false
 							f.continuation =
 								mutableContinuation.replacingCaller(


### PR DESCRIPTION
- Corrected quite a few debugger race problems related to running things in the wrong Thread.
- Stepping performance is muuuch faster, since within a module it no longer has to fetch and style the source.
- CAVEAT: Source code highlighting seems to be broken, but the highlighting for the L1 disassembly during stepping looks correct.