### PR TITLE
Semantic restriction fix + debugger tweak

### DIFF
--- a/avail/src/main/kotlin/avail/AvailRuntime.kt
+++ b/avail/src/main/kotlin/avail/AvailRuntime.kt
@@ -268,6 +268,7 @@ import avail.utility.evaluation.OnceSupplier
 import avail.utility.iterableWith
 import avail.utility.javaNotifyAll
 import avail.utility.javaWait
+import avail.utility.notNullAnd
 import avail.utility.parallelDoThen
 import avail.utility.safeWrite
 import avail.utility.stackToString
@@ -2095,11 +2096,15 @@ class AvailRuntime constructor(
 					argsBuffer.add(functionToRun as AvailObject)
 					argsBuffer.add(tupleFromList(arguments) as AvailObject)
 				}
-				canSkipTypeCheck || functionToRun.code().numArgs() == 0 ->
+				(canSkipTypeCheck || functionToRun.code().numArgs() == 0)
+					&& functionToRun.code().codePrimitive().notNullAnd {
+						hasFlag(CannotFail)
+					} ->
 				{
-					// There's no debugger that will catch this fiber, and the
-					// VM has already vetted the types.  Have the fiber invoke
-					// the function directly with the arguments.
+					// There's no debugger that will catch this fiber, the
+					// VM has already vetted the types, *AND* the function is an
+					// infallible primitive.  Have the fiber invoke the function
+					// directly with the arguments.
 					function = functionToRun
 					chunk = functionToRun.code().startingChunk
 					argsBuffer.addAll(arguments.cast())

--- a/avail/src/main/kotlin/avail/anvil/debugger/AvailDebugger.kt
+++ b/avail/src/main/kotlin/avail/anvil/debugger/AvailDebugger.kt
@@ -1194,7 +1194,8 @@ class AvailDebugger internal constructor (
 		fibersProvider: () -> Collection<A_Fiber>)
 	{
 		val semaphore = Semaphore(0)
-		debuggerModel.gatherFibersThen(fibersProvider) {
+		runtime.whenSafePointDo(debuggerPriority) {
+			debuggerModel.gatherFibers(fibersProvider)
 			(FiberKind.all zip captureButtons).forEach { (kind, button) ->
 				button.isSelected = debuggerModel.isCapturingNewFibers(kind)
 			}
@@ -1221,8 +1222,8 @@ class AvailDebugger internal constructor (
 }
 
 /**
- * Helper function to minimize which variables will presented in scope
- * when using the "inspect" action.
+ * Helper function to minimize which variables will be presented in scope when
+ * using the "inspect" action.
  */
 @Suppress("UNUSED_PARAMETER")
 fun inspect(name: String, value: AvailObject)

--- a/avail/src/main/kotlin/avail/compiler/splitter/MessageSplitter.kt
+++ b/avail/src/main/kotlin/avail/compiler/splitter/MessageSplitter.kt
@@ -393,6 +393,34 @@ private constructor(messageName: A_String)
 		EXCLAMATION_MARK("!"),
 
 		/**
+		 * When compiling indentation-sensitive languages, this message part
+		 * matches whitespace that strictly increases the indentation beyond the
+		 * indentation that was active when starting to parse the message.  Note
+		 * that the start position is not necessarily where the first token of
+		 * the message occurred, since methods may start with leading arguments.
+		 * In that case, the indentation refers to the whitespace at the start
+		 * of the line where that leading argument begins.
+		 *
+		 * The indentation is treated merely as a filter, and no call argument
+		 * is introduced by the notation.
+		 */
+		INCREASE_INDENT("⇥"),
+
+		/**
+		 * When compiling indentation-sensitive languages, this message part
+		 * matches whitespace that exactly matches the indentation that was
+		 * active when starting to parse the message.  Note that the start
+		 * position is not necessarily where the first token of the message
+		 * occurred, since methods may start with leading arguments.  In that
+		 * case, the indentation refers to the whitespace at the start of the
+		 * line where that leading argument begins.
+		 *
+		 * The indentation is treated merely as a filter, and no call argument
+		 * is introduced by the notation.
+		 */
+		MATCH_INDENT("↹"),
+
+		/**
 		 * An octothorp (#) after an [ELLIPSIS] (…) indicates that a
 		 * whole-number-valued literal token should be consumed from the Avail
 		 * source code at this position.  This is accomplished through the use

--- a/avail/src/main/kotlin/avail/interpreter/execution/AvailLoader.kt
+++ b/avail/src/main/kotlin/avail/interpreter/execution/AvailLoader.kt
@@ -47,6 +47,8 @@ import avail.compiler.splitter.MessageSplitter.Metacharacter.DOUBLE_DAGGER
 import avail.compiler.splitter.MessageSplitter.Metacharacter.DOUBLE_QUESTION_MARK
 import avail.compiler.splitter.MessageSplitter.Metacharacter.ELLIPSIS
 import avail.compiler.splitter.MessageSplitter.Metacharacter.EXCLAMATION_MARK
+import avail.compiler.splitter.MessageSplitter.Metacharacter.INCREASE_INDENT
+import avail.compiler.splitter.MessageSplitter.Metacharacter.MATCH_INDENT
 import avail.compiler.splitter.MessageSplitter.Metacharacter.OCTOTHORP
 import avail.compiler.splitter.MessageSplitter.Metacharacter.OPEN_GUILLEMET
 import avail.compiler.splitter.MessageSplitter.Metacharacter.QUESTION_MARK
@@ -2168,6 +2170,8 @@ constructor(
 					DOUBLE_QUESTION_MARK.codepoint,
 					ELLIPSIS.codepoint,
 					EXCLAMATION_MARK.codepoint,
+					INCREASE_INDENT.codepoint,
+					MATCH_INDENT.codepoint,
 					OCTOTHORP.codepoint,
 					OPEN_GUILLEMET.codepoint,
 					QUESTION_MARK.codepoint,
@@ -2298,7 +2302,6 @@ constructor(
 				}
 			}
 			return buildString {
-				val native = quotedName.asNativeString()
 				for ((start, pastEnd, styleString) in styles)
 				{
 					stylesheet[styleString].encloseHtml(this) {

--- a/avail/src/main/kotlin/avail/interpreter/primitive/general/P_BreakPoint.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/general/P_BreakPoint.kt
@@ -53,7 +53,10 @@ object P_BreakPoint : Primitive(0, CanSuspend, CannotFail)
 		val fiber = interpreter.fiber()
 		val runtime = interpreter.runtime
 		// Enter a safe point, invoke the runtime's injected breakpoint handler,
-		// then succeed from the primitive with nil.
+		// then succeed from the primitive with nil.  The debugger, if it is
+		// installed, is expected to put the fiber into a paused state, and the
+		// succeed(nil) advances the fiber to just after the call to this
+		// primitive (and then really pauses).
 		return interpreter.suspendInSafePointThen {
 			runtime.breakpointHandler(fiber)
 			succeed(nil)

--- a/avail/src/main/kotlin/avail/utility/structures/LeftistHeap.kt
+++ b/avail/src/main/kotlin/avail/utility/structures/LeftistHeap.kt
@@ -82,7 +82,7 @@ sealed class LeftistHeap<Value : Comparable<Value>>(
 	 */
 	abstract fun without(value: Value): LeftistHeap<Value>
 
-	/** Collect the heap's elements in a [List] in arbitrary order. */
+	/** Collect the heap's elements in a [List] in sorted order. */
 	fun toList(): List<Value>
 	{
 		val list = mutableListOf<Value>()


### PR DESCRIPTION
- Fixed a recent bug where semantic restrictions were showing stack traces due to eliding the base frame.
- Breakpoint primitive works again.
- Added (unused) MATCH_INDENT and INCREASE_INDENT metacharacters.