### PR TITLE
- Fixed AvailEditor.forceWrite to correctly report exceptions.

### DIFF
--- a/avail/src/main/kotlin/avail/anvil/shortcuts/AvailEditorShortcuts.kt
+++ b/avail/src/main/kotlin/avail/anvil/shortcuts/AvailEditorShortcuts.kt
@@ -36,7 +36,6 @@ import avail.anvil.AvailEditor
 import avail.anvil.actions.RefreshStylesheetAction
 import avail.anvil.editor.GoToDialog
 import avail.anvil.shortcuts.ModifierKey.ALT
-import avail.anvil.shortcuts.ModifierKey.BUTTON1
 import avail.anvil.shortcuts.ModifierKey.CTRL
 import avail.anvil.shortcuts.ModifierKey.Companion.menuShortcutKeyMaskEx
 import avail.anvil.shortcuts.ModifierKey.SHIFT
@@ -109,9 +108,9 @@ object OpenPhraseViewShortcut
  *
  * @author Richard Arriaga
  */
-object RefreshShortcut: AvailEditorShortcut(KeyCode.VK_F5.with())
+object RebuildShortcut: AvailEditorShortcut(KeyCode.VK_F5.with())
 {
-	override val actionMapKey: String = "refresh"
+	override val actionMapKey: String = "rebuild"
 	override val description: String = "Rebuild and Refresh Module"
 }
 

--- a/avail/src/main/kotlin/avail/anvil/text/TextKits.kt
+++ b/avail/src/main/kotlin/avail/anvil/text/TextKits.kt
@@ -63,7 +63,7 @@ import avail.anvil.shortcuts.OutdentShortcut
 import avail.anvil.shortcuts.PascalCaseShortcut
 import avail.anvil.shortcuts.PrintAllRenderingSolutionsShortcut
 import avail.anvil.shortcuts.RedoShortcut
-import avail.anvil.shortcuts.RefreshShortcut
+import avail.anvil.shortcuts.RebuildShortcut
 import avail.anvil.shortcuts.RefreshStylesheetShortcut
 import avail.anvil.shortcuts.SaveShortcut
 import avail.anvil.shortcuts.SnakeCaseShortcut
@@ -188,7 +188,7 @@ class AvailEditorKit constructor(workbench: AvailWorkbench) : CodeKit(workbench)
 		InsertLineCommentAtStart,
 		OpenStructureView,
 		OpenPhraseView,
-		Refresh,
+		Rebuild,
 		WrapInBlockComment,
 		RefreshStylesheet,
 		PrintAllRenderingSolutions
@@ -475,11 +475,12 @@ private object GoToDialogAction: TextAction(GoToDialogShortcut.actionMapKey)
 /**
  * Rebuild the open editor's module and refresh the screen style.
  */
-private object Refresh: TextAction(RefreshShortcut.actionMapKey)
+private object Rebuild: TextAction(RebuildShortcut.actionMapKey)
 {
 	override fun actionPerformed(e: ActionEvent)
 	{
 		val editor = e.editor
+		editor.forceWrite()
 		val workbench = editor.workbench
 		workbench.clearTranscript()
 		val buildTask = BuildTask(workbench, editor.resolvedName)

--- a/avail/src/main/kotlin/avail/resolver/FileSystemModuleRootResolver.kt
+++ b/avail/src/main/kotlin/avail/resolver/FileSystemModuleRootResolver.kt
@@ -397,12 +397,35 @@ class FileSystemModuleRootResolver constructor(
 		val data = ByteBuffer.wrap(fileContents)
 		val path = Path.of(reference.uri)
 		val tempPath = path.parent.resolve(tempFilePrefix() + path.fileName)
-		val tempFile = fileManager.ioSystem.openFile(
-			tempPath,
-			EnumSet.of(
-				StandardOpenOption.CREATE,
-				StandardOpenOption.TRUNCATE_EXISTING,
-				StandardOpenOption.WRITE))
+		val tempFile = try
+		{
+			fileManager.ioSystem.openFile(
+				tempPath,
+				EnumSet.of(
+					StandardOpenOption.CREATE,
+					StandardOpenOption.TRUNCATE_EXISTING,
+					StandardOpenOption.WRITE))
+		}
+		catch (e: IOException)
+		{
+			failureHandler(StandardErrorCode.IO_EXCEPTION, e)
+			return
+		}
+		catch (e: IllegalArgumentException)
+		{
+			failureHandler(StandardErrorCode.IO_EXCEPTION, e)
+			return
+		}
+		catch (e: UnsupportedOperationException)
+		{
+			failureHandler(StandardErrorCode.IO_EXCEPTION, e)
+			return
+		}
+		catch (e: SecurityException)
+		{
+			failureHandler(FileErrorCode.PERMISSIONS, e)
+			return
+		}
 		tempFile.write(
 			data,
 			0,


### PR DESCRIPTION
- FileSystemModuleRootResolver.saveFile now handles open file failures correctly
- Renamed Refresh to Rebuild as the F5 editor action is running a build task so Rebuild is a more accurate name.