### PR TITLE
Added full support and parsing diagnostics for new metacharacters

### DIFF
--- a/avail/.idea/dictionaries/markvangulik.xml
+++ b/avail/.idea/dictionaries/markvangulik.xml
@@ -157,6 +157,7 @@
       <w>supremum</w>
       <w>synchronizer</w>
       <w>tailrec</w>
+      <w>tokenless</w>
       <w>unboundedly</w>
       <w>uncaptured</w>
       <w>undeclare</w>

--- a/avail/src/main/kotlin/avail/anvil/Styles.kt
+++ b/avail/src/main/kotlin/avail/anvil/Styles.kt
@@ -1165,12 +1165,12 @@ class StylePatternCompiler private constructor(
 								start + 1, source.substring(start, i)))
 					}
 				}
-				c.toChar().isWhitespace() ->
+				Character.isWhitespace(c) ->
 				{
 					// No action required.
 				}
 				else -> tokens.add(InvalidToken(
-					start + 1, c.toChar().toString()))
+					start + 1, buildString { appendCodePoint(c) }))
 			}
 		}
 		tokens.add(EndOfPatternToken(i + 1))

--- a/avail/src/main/kotlin/avail/compiler/AvailCompiler.kt
+++ b/avail/src/main/kotlin/avail/compiler/AvailCompiler.kt
@@ -1350,6 +1350,7 @@ class AvailCompiler constructor(
 				false,
 				false,
 				emptyList(),
+				null,
 				PartialSubexpressionList(
 					loader.rootBundleTree, superexpressions),
 				continuation))
@@ -1389,6 +1390,7 @@ class AvailCompiler constructor(
 				false,
 				false,
 				emptyList(),
+				null,
 				PartialSubexpressionList(
 					loader.rootBundleTree, superexpressions),
 				continuation))
@@ -4687,7 +4689,7 @@ class AvailCompiler constructor(
 		 * @param continuation
 		 *   What to invoke with the collection of successor [ParserState]s.
 		 */
-		private fun skipWhitespaceAndComments(
+		fun skipWhitespaceAndComments(
 			start: ParserState,
 			continuation: (List<ParserState>)->Unit)
 		{

--- a/avail/src/main/kotlin/avail/compiler/ParsingOperation.kt
+++ b/avail/src/main/kotlin/avail/compiler/ParsingOperation.kt
@@ -702,7 +702,7 @@ enum class ParsingOperation constructor(
 									"the indentation to exactly match that " +
 										"at the beginning of the phrase. The " +
 										"indentation at the beginning was " +
-										"${initialIndent.q}, but the current" +
+										"${initialIndent.q}, but the current " +
 										"line begins with ${currentIndent.q}.")
 							}
 						}

--- a/avail/src/main/kotlin/avail/compiler/ParsingStepState.kt
+++ b/avail/src/main/kotlin/avail/compiler/ParsingStepState.kt
@@ -35,11 +35,19 @@ package avail.compiler
 import avail.compiler.AvailCompiler.PartialSubexpressionList
 import avail.compiler.ParsingOperation.BRANCH_FORWARD
 import avail.compiler.splitter.MessageSplitter
+import avail.descriptor.module.A_Module
 import avail.descriptor.phrases.A_Phrase
+import avail.descriptor.phrases.A_Phrase.Companion.allTokens
 import avail.descriptor.phrases.SendPhraseDescriptor
+import avail.descriptor.representation.AvailObject
 import avail.descriptor.tokens.A_Token
+import avail.descriptor.tuples.A_String
+import avail.descriptor.tuples.A_String.Companion.copyStringFromToCanDestroy
+import avail.descriptor.tuples.A_Tuple.Companion.tupleCodePointAt
+import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.utility.PrefixSharingList.Companion.append
 import avail.utility.PrefixSharingList.Companion.withoutLast
+import kotlin.math.min
 
 /**
  * [ParsingStepState] captures the current state while parsing an expression.
@@ -77,6 +85,13 @@ import avail.utility.PrefixSharingList.Companion.withoutLast
  *   and consumed for the current method or macro invocation being parsed.
  *   These also include the one-based part index of the static token within the
  *   [MessageSplitter]'s tuple of tokens.
+ * @property initialIndentationString
+ *   An optional, lazy [A_String], computed only if an indentation-sensitive
+ *   instruction has asked what the initial indentation level (whitespace
+ *   string) was. This was the indentation at the [initialTokenPosition] if we
+ *   started with a keyword, otherwise the leftmost token of the first argument,
+ *   or if that's tokenless somehow, the leftmost token of the first argument
+ *   that has any tokens.
  * @property superexpressions
  *   The [PartialSubexpressionList] (or null) which forms a chain of partially
  *   constructed outer phrases, used for describing the circumstance of a syntax
@@ -95,6 +110,7 @@ internal class ParsingStepState constructor(
 	var consumedAnything: Boolean,
 	var consumedAnythingBeforeLatestArgument: Boolean,
 	var staticTokens: List<Pair<A_Token, Int>>,
+	private var initialIndentationString: A_String? = null,
 	var superexpressions: PartialSubexpressionList?,
 	var continuation: (ParserState, A_Phrase)->Unit)
 {
@@ -116,17 +132,20 @@ internal class ParsingStepState constructor(
 			consumedAnything,
 			consumedAnythingBeforeLatestArgument,
 			staticTokens,
+			initialIndentationString,
 			superexpressions,
 			continuation)
 		copy.update()
 		return copy
 	}
 
+	/** Modify the state to have one more phrase. */
 	fun push(phrase: A_Phrase)
 	{
 		argsSoFar = argsSoFar.append(phrase)
 	}
 
+	/** Modify the state to have one fewer phrase, returning it. */
 	fun pop(): A_Phrase
 	{
 		val phrase = argsSoFar.last()
@@ -134,15 +153,133 @@ internal class ParsingStepState constructor(
 		return phrase
 	}
 
+	/**
+	 * Modify the state to have one more marker [Int] value, used to track
+	 * whether a repeated subsection made any progress.
+	 */
 	fun pushMarker(marker: Int)
 	{
 		marksSoFar = marksSoFar.append(marker)
 	}
 
+	/**
+	 * Modify the state to have one fewer marker [Int] value, used to track
+	 * whether a repeated subsection made any progress.  Answer the marker.
+	 */
 	fun popMarker(): Int
 	{
 		val marker = marksSoFar.last()
 		marksSoFar = marksSoFar.withoutLast()
 		return marker
+	}
+
+	/**
+	 * Scan forward starting at the current parse position to skip any
+	 * whitespace, then scan backward through the whitespace.  If during that
+	 * scan we reach a linefeed (or the beginning of the source), capture the
+	 * whitespace following that linefeed and return it.  Otherwise answer null.
+	 */
+	fun currentIndentationString(): A_String?
+	{
+		val source = start.lexingState.compilationContext.source
+		val size = source.tupleSize
+		var pos = start.position
+		while (pos <= size
+			&& Character.isWhitespace(source.tupleCodePointAt(pos)))
+		{
+			pos++
+		}
+		// Pos is now just past any whitespace.  Note that a lexer would still
+		// have to consume that whitespace, since we're parsing at `start`.
+		var back = pos - 1
+		while(back >= 1)
+		{
+			val codePoint = source.tupleCodePointAt(back)
+			if (codePoint == '\n'.code) break
+			if (!Character.isWhitespace(codePoint)) return null
+			back--
+		}
+		return source.copyStringFromToCanDestroy(back + 1, pos - 1, false)
+	}
+
+	/**
+	 * Answer the string of whitespace that begins the line containing the
+	 * leftmost parsed token of this partially parsed phrase or any of the
+	 * subphrases that have been parsed for it.  Save this in the current
+	 * parsing state, if it's not already present.
+	 */
+	fun initialIndentationString(): A_String
+	{
+		var str = initialIndentationString
+		if (str === null)
+		{
+			str = computeIndentationStringAt(computeInitialPosition())
+			initialIndentationString = str
+		}
+		return str
+	}
+
+	/**
+	 * Answer the string of whitespace that begins the line containing the
+	 * given one-based character position in the source.  The position should be
+	 * the first character of a token, but this is not required.
+	 */
+	private fun computeIndentationStringAt(position: Int): A_String
+	{
+		val source = start.lexingState.compilationContext.source
+		val previousLineEnd = (position - 1 downTo 1).firstOrNull { i ->
+			source.tupleCodePointAt(i) == '\n'.code
+		} ?: 0
+		val firstNonBlankOnLine =
+			(previousLineEnd + 1 .. position).firstOrNull { i ->
+				!Character.isWhitespace(source.tupleCodePointAt(i))
+			} ?: position
+		return source.copyStringFromToCanDestroy(
+			previousLineEnd + 1, firstNonBlankOnLine - 1, false
+		).makeShared()
+	}
+
+	/**
+	 * Compute the initial position for the phrase being parsed.
+	 */
+	private fun computeInitialPosition(): Int
+	{
+		val source = start.lexingState.compilationContext.source
+		val size = source.tupleSize
+		var position = initialTokenPosition.position
+		// Skip whitespace after parse position.
+		while (position <= size
+			&& Character.isWhitespace(source.tupleCodePointAt(position)))
+		{
+			position++
+		}
+		var leftmostTokenPosition = position
+		// The phrase we're in the process of building might have started with
+		// a leading phrase, so .
+		val module = start.lexingState.compilationContext.module
+		for (arg in argsSoFar)
+		{
+			val start = startOfPhrase(arg, module)
+			if (start != null)
+			{
+				leftmostTokenPosition = min(leftmostTokenPosition, start)
+				break
+			}
+		}
+		return leftmostTokenPosition
+	}
+
+	/**
+	 * Given a [phrase], answer its starting position in the source, or null if
+	 * it contains no tokens from the current [module].
+	 *
+	 * This can be inefficient, as it computes the collection of all tokens in
+	 * the phrase.
+	 */
+	private fun startOfPhrase(phrase: A_Phrase, module: A_Module): Int?
+	{
+		return phrase.allTokens
+			.filter { it.isInCurrentModule(module) }
+			.minOfOrNull(AvailObject::start)
 	}
 }

--- a/avail/src/main/kotlin/avail/compiler/splitter/CheckIndent.kt
+++ b/avail/src/main/kotlin/avail/compiler/splitter/CheckIndent.kt
@@ -1,0 +1,136 @@
+/*
+ * CheckIndent.kt
+ * Copyright © 1993-2023, The Avail Foundation, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of the contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package avail.compiler.splitter
+
+import avail.compiler.ParsingOperation.INCREASE_INDENT
+import avail.compiler.ParsingOperation.MATCH_INDENT
+import avail.compiler.splitter.CheckIndent.IndentationMatchType
+import avail.compiler.splitter.CheckIndent.IndentationMatchType.IncreaseIndent
+import avail.compiler.splitter.CheckIndent.IndentationMatchType.MatchIndent
+import avail.compiler.splitter.MessageSplitter.Metacharacter
+import avail.descriptor.phrases.A_Phrase
+import avail.descriptor.types.A_Type
+
+/**
+ * A [CheckIndent] expression is an occurrence of either the
+ * [Metacharacter.INCREASE_INDENT] ("⇥") or
+ * [Metacharacter.MATCH_INDENT] ("↹") in a message name.  The parse position,
+ * after skipping any whitespace, must be immediately after whitespace that
+ * starts a line, otherwise the parse theory is rejected.  That leading
+ * whitespace is compared to the whitespace that occurred on the line at which
+ * the current phrase began (including a leading argument, if any).  If the
+ * [indentationMatchType] is [MatchIndent], the indentation strings must be
+ * equal to proceed past this test.  If the match type is [IncreaseIndent], the
+ * current indentation must be an extension of the original indentation to pass.
+ *
+ * @property indentationMatchType
+ *   An [IndentationMatchType] that selects the kind of matching to be
+ *   performed.
+ *
+ * @author Mark van Gulik &lt;mark@availlang.org&gt;
+ *
+ * @constructor
+ *
+ * Construct a `CheckIndent`.
+ *
+ * @param startInName
+ *   The [CheckIndent]'s position in the message name.
+ * @param pastEndInName
+ *   Just past the [CheckIndent] in the message name.
+ * @param indentationMatchType
+ *   An [IndentationMatchType] that selects the kind of matching to be
+ *   performed.
+ */
+internal class CheckIndent constructor(
+	startInName: Int,
+	pastEndInName: Int,
+	private val indentationMatchType: IndentationMatchType
+) : Expression(startInName, pastEndInName)
+{
+	enum class IndentationMatchType
+	{
+		MatchIndent,
+		IncreaseIndent
+	}
+
+	override fun applyCaseInsensitive(): CheckIndent = this
+
+	override fun children(): List<Expression> = emptyList()
+
+	override fun checkType(argumentType: A_Type, sectionNumber: Int)
+	{
+		assert(false) {
+			"checkType() should not be called for a CheckIndent expression"
+		}
+	}
+
+	override fun emitOn(
+		phraseType: A_Type,
+		generator: InstructionGenerator,
+		wrapState: WrapState): WrapState
+	{
+		// Tidy up any partially-constructed groups and invoke the
+		// appropriate prefix function.  Note that the partialListsCount is
+		// constrained to always be at least one here.
+		generator.flushDelayed()
+		when (indentationMatchType)
+		{
+			MatchIndent -> generator.emit(this, MATCH_INDENT)
+			IncreaseIndent -> generator.emit(this, INCREASE_INDENT)
+		}
+		return wrapState
+	}
+
+	override fun printWithArguments(
+		arguments: Iterator<A_Phrase>?,
+		builder: StringBuilder,
+		indent: Int)
+	{
+		when (indentationMatchType)
+		{
+			MatchIndent -> builder.appendCodePoint(
+				Metacharacter.MATCH_INDENT.codepoint)
+			IncreaseIndent -> builder.appendCodePoint(
+				Metacharacter.INCREASE_INDENT.codepoint)
+		}
+	}
+
+	override val shouldBeSeparatedOnLeft: Boolean get() = true
+
+	override val shouldBeSeparatedOnRight: Boolean get() = true
+
+	override fun mightBeEmpty(phraseType: A_Type) = true
+
+	override fun checkListStructure(phrase: A_Phrase): Boolean =
+		throw RuntimeException(
+			"checkListStructure() inapplicable for CheckIndent.")
+}

--- a/avail/src/main/kotlin/avail/descriptor/phrases/A_Phrase.kt
+++ b/avail/src/main/kotlin/avail/descriptor/phrases/A_Phrase.kt
@@ -685,7 +685,7 @@ interface A_Phrase : A_BasicObject {
 			dispatch { o_TokenIndicesInName(it) }
 
 		/**
-		 * Answer all [tokens][A_Token] belong to the receiver or its
+		 * Answer all [tokens][A_Token] belonging to the receiver or its
 		 * subexpressions, lexically ordered, without positionless synthetic
 		 * tokens.
 		 *

--- a/avail/src/main/kotlin/avail/descriptor/variables/VariableSharedGlobalDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/variables/VariableSharedGlobalDescriptor.kt
@@ -322,10 +322,10 @@ class VariableSharedGlobalDescriptor private constructor(
 	companion object
 	{
 		/**
-		 * Create a write-once, shared variable. This method should only be used
-		 * to create module constants, and *maybe* eventually local constants.
-		 * It should *not* be used for converting existing variables to be
-		 * shared.
+		 * Create a shared variable, which may be write-once if so indicated.
+		 * This method should only be used to create module constants, and
+		 * *maybe* eventually local constants. It should *not* be used for
+		 * converting existing variables to be shared.
 		 *
 		 * @param variableType
 		 *   The [variable&#32;type][VariableTypeDescriptor].


### PR DESCRIPTION
- "↹" match indent,
- "⇥" increase indent,
- "↹⁇" match indent *or* stay on same line, and
- "⇥⁇" increase indent *or* stay on same line. Note that this isn't quite what the "⁇" suffix does for other message parts, as the "not matching indent" path has the check to ensure there are no line breaks in the whitespace (and comments).