### PR TITLE
Debugger shows inspector tree, plus o_FirstIndexOf() and o_FirstIndexOfOr().

### DIFF
--- a/avail/.idea/inspectionProfiles/Project_Default.xml
+++ b/avail/.idea/inspectionProfiles/Project_Default.xml
@@ -184,6 +184,7 @@
       <option name="myAdditionalJavadocTags" value="return" />
       <IGNORE_ACCESSORS value="true" />
     </inspection_tool>
+    <inspection_tool class="JavaIoSerializableObjectMustHaveReadResolve" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JavaLangImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="JavadocDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ADDITIONAL_TAGS" value="return" />
@@ -454,11 +455,7 @@
       <option name="ADD_NONJAVA_TO_ENTRIES" value="false" />
       <option name="ADD_EXPORTED_PACKAGES_AND_SERVICES_TO_ENTRIES" value="false" />
       <option name="selected" value="false" />
-      <option name="ADD_ANDROID_COMPONENTS_TO_ENTRIES" value="false" />
-      <option name="selected" value="false" />
-      <option name="selected" value="false" />
       <option name="DEPRECATED_ENTRY_POINT" value="false" />
-      <option name="selected" value="false" />
     </inspection_tool>
   </profile>
 </component>

--- a/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
+++ b/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
@@ -1307,7 +1307,6 @@ class AvailWorkbench internal constructor(
 		modules: AbstractWorkbenchTreeNode,
 		entryPoints: AbstractWorkbenchTreeNode)
 	{
-		// Process the expansion/
 		mapOf(
 			moduleTree to modules,
 			entryPointsTree to entryPoints
@@ -1336,8 +1335,9 @@ class AvailWorkbench internal constructor(
 	}
 
 	/**
-	 * Answer a [tree&#32;node][TreeNode] that represents the (invisible) root
-	 * of the Avail module tree.
+	 * Produce a [tree&#32;node][TreeNode] that represents the (invisible) root
+	 * of the Avail module tree.  Pass it to the provided function when it's
+	 * ready, which might be within another [Thread].
 	 *
 	 * @param withTreeNode
 	 *   The lambda that accepts the (invisible) root of the module tree.

--- a/avail/src/main/kotlin/avail/descriptor/functions/PrimitiveCompiledCodeDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/functions/PrimitiveCompiledCodeDescriptor.kt
@@ -266,7 +266,7 @@ class PrimitiveCompiledCodeDescriptor internal constructor(
 	}
 
 	override fun o_NameForDebugger(self: AvailObject) =
-		super.o_NameForDebugger(self) + "($primitive): " + methodName
+		super.o_NameForDebugger(self) + " (${primitive.simpleName})"
 
 	override fun o_ReturnTypeIfPrimitiveFails(self: AvailObject): A_Type =
 		returnTypeIfPrimitiveFails

--- a/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
@@ -1435,6 +1435,13 @@ abstract class AbstractDescriptor protected constructor (
 		startIndex: Int,
 		endIndex: Int): Int
 
+	abstract fun o_FirstIndexOfOr(
+		self: AvailObject,
+		value: A_BasicObject,
+		otherValue: A_BasicObject,
+		startIndex: Int,
+		endIndex: Int): Int
+
 	abstract fun o_SetContinuation (
 		self: AvailObject,
 		value: A_Continuation)

--- a/avail/src/main/kotlin/avail/descriptor/representation/AvailObjectFieldHelper.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AvailObjectFieldHelper.kt
@@ -200,11 +200,10 @@ class AvailObjectFieldHelper(
 		}
 	}
 
-	@Suppress("unused")
-	fun describeForDebugger(): Any? = when {
+	fun describeForDebugger(): Array<*> = when {
 		forcedChildren !== null -> forcedChildren
 		value is AvailObject -> value.describeForDebugger()
 		value is AvailIntegerValueHelper -> emptyArray<Any>()
-		else -> value
+		else -> arrayOf(value)
 	}
 }

--- a/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
@@ -2815,6 +2815,14 @@ protected constructor (
 		endIndex: Int
 	): Int = unsupported
 
+	override fun o_FirstIndexOfOr(
+		self: AvailObject,
+		value: A_BasicObject,
+		otherValue: A_BasicObject,
+		startIndex: Int,
+		endIndex: Int
+	): Int = unsupported
+
 	override fun o_LastIndexOf(
 		self: AvailObject,
 		value: A_BasicObject,

--- a/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
@@ -496,6 +496,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.copyAsMutableObjectTuple
 import avail.descriptor.tuples.A_Tuple.Companion.copyTupleFromToCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.extractNybbleFromTupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.firstIndexOf
+import avail.descriptor.tuples.A_Tuple.Companion.firstIndexOfOr
 import avail.descriptor.tuples.A_Tuple.Companion.hashFromTo
 import avail.descriptor.tuples.A_Tuple.Companion.isBetterRepresentationThan
 import avail.descriptor.tuples.A_Tuple.Companion.lastIndexOf
@@ -4046,6 +4047,14 @@ class IndirectionDescriptor private constructor(
 		startIndex: Int,
 		endIndex: Int
 	): Int = self .. { firstIndexOf(value, startIndex, endIndex) }
+
+	override fun o_FirstIndexOfOr(
+		self: AvailObject,
+		value: A_BasicObject,
+		otherValue: A_BasicObject,
+		startIndex: Int,
+		endIndex: Int
+	): Int = self .. { firstIndexOfOr(value, otherValue, startIndex, endIndex) }
 
 	override fun o_LastIndexOf(
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/tuples/A_Tuple.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/A_Tuple.kt
@@ -657,6 +657,33 @@ interface A_Tuple : A_BasicObject, Iterable<AvailObject>
 		): Int = dispatch { o_FirstIndexOf(it, value, startIndex, endIndex) }
 
 		/**
+		 * Search for one of two particular values in the tuple, starting at the
+		 * given index and working forward.  The first match of either [value]
+		 * or [otherValue] ends the search.
+		 *
+		 * @param value
+		 *   The value to search for in the receiver.
+		 * @param otherValue
+		 *   The other value to search for in the receiver.
+		 * @param startIndex
+		 *   The position at which to start scanning.
+		 * @param endIndex
+		 *   The position at which to stop scanning, which should be >= the
+		 *   startIndex for a non-empty range.
+		 * @return
+		 *   The first encountered index of the code point when scanning forward
+		 *   from the [startIndex].  If neither value is found, answer 0.
+		 */
+		fun A_Tuple.firstIndexOfOr(
+			value: A_BasicObject,
+			otherValue: A_BasicObject,
+			startIndex: Int,
+			endIndex: Int
+		): Int = dispatch {
+			o_FirstIndexOfOr(it, value, otherValue, startIndex, endIndex)
+		}
+
+		/**
 		 * Calculate the hash of the subtuple spanning the two indices.
 		 *
 		 * @param startIndex

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
@@ -692,6 +692,24 @@ protected constructor(
 		return 0
 	}
 
+	override fun o_FirstIndexOfOr(
+		self: AvailObject,
+		value: A_BasicObject,
+		otherValue: A_BasicObject,
+		startIndex: Int,
+		endIndex: Int
+	): Int
+	{
+		if (value.equals(otherValue))
+			return o_FirstIndexOf(self, value, startIndex, endIndex)
+		for (i in startIndex..endIndex)
+		{
+			val element = self.tupleAt(i)
+			if (element.equals(value) || element.equals(otherValue)) return i
+		}
+		return 0
+	}
+
 	// Compute tuple's hash value over the given range.
 	override fun o_HashFromTo(
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/types/IntegerRangeTypeDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/types/IntegerRangeTypeDescriptor.kt
@@ -148,6 +148,15 @@ private constructor(
 		UPPER_BOUND
 	}
 
+	override fun o_NameForDebugger(self: AvailObject): String
+	{
+		return (super.o_NameForDebugger(self)
+			+ " "
+			+ (if (lowerInclusive) "incl" else "excl")
+			+ ", "
+			+ (if (upperInclusive) "incl" else "excl"))
+	}
+
 	override fun printObjectOnAvoidingIndent(
 		self: AvailObject,
 		builder: StringBuilder,

--- a/avail/src/main/kotlin/avail/descriptor/types/PrimitiveTypeDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/types/PrimitiveTypeDescriptor.kt
@@ -32,6 +32,7 @@
 package avail.descriptor.types
 
 import avail.AvailRuntimeSupport
+import avail.annotations.HideFieldInDebugger
 import avail.annotations.ThreadSafe
 import avail.compiler.AvailCompiler
 import avail.descriptor.atoms.AtomDescriptor
@@ -151,6 +152,7 @@ private constructor(
 		 * The low 32 bits are used for caching the hash, and the upper 32 are
 		 * for the ordinal of the primitive type.
 		 */
+		@HideFieldInDebugger
 		HASH_AND_MORE;
 
 		companion object

--- a/avail/src/main/kotlin/avail/utility/MathExtensions.kt
+++ b/avail/src/main/kotlin/avail/utility/MathExtensions.kt
@@ -1,0 +1,53 @@
+/*
+ * MathExtensions.kt
+ * Copyright © 1993-2022, The Avail Foundation, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of the contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package avail.utility
+
+/** The value 0x0101010101010101L, which has the low bit set in each byte. */
+const val lowBitsOfBytes: Long = 0x0101010101010101L
+
+/** The value 0x8080808080808080L, which has the high bit set in each byte. */
+const val highBitsOfBytes: Long = lowBitsOfBytes.shl(7)
+
+/** Answer true iff any byte of the receiver is zero. */
+fun Long.hasZeroByte(): Boolean =
+	(this - lowBitsOfBytes) and this.inv() and highBitsOfBytes != 0L
+
+/** The value 0x0001000100010001L, which has the low bit set in each short. */
+const val lowBitsOfShorts: Long = 0x0001000100010001L
+
+/** The value 0x8000800080008000L, which has the high bit set in each short. */
+const val highBitsOfShorts: Long = lowBitsOfShorts.shl(15)
+
+/** Answer true iff any short of the receiver is zero. */
+fun Long.hasZeroShort(): Boolean =
+	(this - lowBitsOfShorts) and this.inv() and highBitsOfShorts != 0L


### PR DESCRIPTION
Debug window now shows a tree view for the current stack frame, presented with information that's produced for the IntelliJ debugger.
- o_FirstIndexOf() now does a bulk scan by long slots, with a 2's complement trick for bytes or shorts or 21-bit code points.
- Added o_FirstIndexOfOr() that looks for one of two values in a range of a tuple.  Optimized like o_FirstIndexOf().
- Unfortunately, the performance seems unaffected, and profiles show this was probably wasted effort.