### PR TITLE
[IDEA plugin] Create Avail project wizard

### DIFF
--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleBuilder.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleBuilder.kt
@@ -38,6 +38,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.module.ModuleTypeManager
 import com.intellij.openapi.roots.ModifiableRootModel
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider
 
 /**
  * The [ModuleBuilder] for building an Avail module.
@@ -60,5 +61,7 @@ class AvailModuleBuilder: ModuleBuilder()
 	override fun getCustomOptionsStep(
 		context: WizardContext,
 		parentDisposable: Disposable
-	): ModuleWizardStep = AvailModuleWizardStep()
+	): ModuleWizardStep = AvailModuleWizardStep(this)
+
+
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -53,6 +53,12 @@ class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 		}
 	}
 
+	/**
+	 * Given a Module and the [createProjectPanel] fields,
+	 * create the configuration for the module.
+	 *
+	 * @return The AvailProjectTemplate.Config object representing the configuration.
+	 */
 	private val Module.config get() =
 		createProjectPanel.let { panel ->
 			AvailProjectTemplate.Config(
@@ -68,6 +74,11 @@ class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 			)
 		}
 
+	/**
+	 * Represents the panel used to create a new project.
+	 *
+	 * @property createProjectPanel The instance of the CreateAvailProjectPanel class used to display the create project form.
+	 */
 	private val createProjectPanel: CreateAvailProjectPanel =
 		CreateAvailProjectPanel()
 

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -50,49 +50,49 @@ import javax.swing.JComponent
 class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 {
 
-  init
-  {
-    // this listener is called after you choose a location and a name
-    // even though we ask for the Avail module roots and config first
-    builder.addListener { module ->
-      AvailProjectTemplate.create(module.config)
-    }
-  }
+	init
+	{
+		// this listener is called after you choose a location and a name
+		// even though we ask for the Avail module roots and config first
+		builder.addListener { module ->
+			AvailProjectTemplate.create(module.config)
+		}
+	}
 
-  /**
-   * Given a Module and the [createProjectPanel] fields, create the
-   * [AvailProjectTemplate.Config] for the project to be created.
-   */
-  private val Module.config
-    get() =
-      createProjectPanel.let { panel ->
-        AvailProjectTemplate.Config(
-          projectLocation = moduleFilePath.substringBeforeLast("/"),
-          fileName = name,
-          rootsDir = panel.rootsDirField.input.ifEmpty { "roots" },
-          rootName = panel.rootNameField.input.ifEmpty { name },
-          importStyles = panel.importStyles.isSelected,
-          importTemplates = panel.importTemplates.isSelected,
-          libraryName = panel.libraryNameField.input.ifEmpty { null },
-          selectedLibrary = panel.selectedLibrary,
-          environmentSettings = GlobalEnvironmentSettingsV1()
-        )
-      }
+	/**
+	 * Given a Module and the [createProjectPanel] fields, create the
+	 * [AvailProjectTemplate.Config] for the project to be created.
+	 */
+	private val Module.config
+		get() =
+			createProjectPanel.let { panel ->
+				AvailProjectTemplate.Config(
+					projectLocation = moduleFilePath.substringBeforeLast("/"),
+					fileName = name,
+					rootsDir = panel.rootsDirField.input.ifEmpty { "roots" },
+					rootName = panel.rootNameField.input.ifEmpty { name },
+					importStyles = panel.importStyles.isSelected,
+					importTemplates = panel.importTemplates.isSelected,
+					libraryName = panel.libraryNameField.input.ifEmpty { null },
+					selectedLibrary = panel.selectedLibrary,
+					environmentSettings = GlobalEnvironmentSettingsV1()
+				)
+			}
 
-  /**
-   * Represents the panel used to create a new project.
-   *
-   * @property createProjectPanel
-   *   The instance of the CreateAvailProjectPanel class used to display the
-   *   create project form.
-   */
-  private val createProjectPanel: CreateAvailProjectPanel =
-    CreateAvailProjectPanel()
+	/**
+	 * Represents the panel used to create a new project.
+	 *
+	 * @property createProjectPanel
+	 *   The instance of the CreateAvailProjectPanel class used to display the
+	 *   create project form.
+	 */
+	private val createProjectPanel: CreateAvailProjectPanel =
+		CreateAvailProjectPanel()
 
-  override fun getComponent(): JComponent =
-    createProjectPanel
+	override fun getComponent(): JComponent =
+		createProjectPanel
 
-  override fun updateDataModel()
-  {
-  }
+	override fun updateDataModel()
+	{
+	}
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -31,24 +31,37 @@
  */
 package org.availlang.intellij.plugin.module
 
+import avail.anvil.environment.GlobalEnvironmentSettingsV1
 import com.intellij.ide.util.projectWizard.ModuleWizardStep
 import javax.swing.JComponent
-import javax.swing.JLabel
 
 /**
  * The [ModuleWizardStep] used to set up a new Avail project.
  *
  * @author Richard Arriaga
  */
-class AvailModuleWizardStep: ModuleWizardStep()
+class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 {
-	override fun getComponent(): JComponent
+
+	init
 	{
-		return JLabel("TODO!")
+		// this listener is called after you choose a location and a name
+		// even though we ask for the Avail module name and config first
+	  builder.addListener { module ->
+			createProjectPanel.create(
+				module.moduleFilePath.substringBeforeLast("/"), // this is the path to the parent of the module file
+				module.name
+			)
+		}
 	}
+
+	private val createProjectPanel: CreateAvailProjectPanel =
+		CreateAvailProjectPanel(GlobalEnvironmentSettingsV1())
+
+	override fun getComponent(): JComponent =
+		createProjectPanel
 
 	override fun updateDataModel()
 	{
-
 	}
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -40,6 +40,12 @@ import javax.swing.JComponent
  * The [ModuleWizardStep] used to set up a new Avail project.
  *
  * @author Richard Arriaga
+ *
+ * @constructor
+ * Construct an [AvailModuleWizardStep].
+ *
+ * @param builder
+ *   The [AvailModuleBuilder] used to construct the Avail [Module].
  */
 class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 {

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -33,6 +33,7 @@ package org.availlang.intellij.plugin.module
 
 import avail.anvil.environment.GlobalEnvironmentSettingsV1
 import com.intellij.ide.util.projectWizard.ModuleWizardStep
+import com.intellij.openapi.module.Module
 import javax.swing.JComponent
 
 /**
@@ -46,17 +47,29 @@ class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 	init
 	{
 		// this listener is called after you choose a location and a name
-		// even though we ask for the Avail module name and config first
+		// even though we ask for the Avail module roots and config first
 	  builder.addListener { module ->
-			createProjectPanel.create(
-				module.moduleFilePath.substringBeforeLast("/"), // this is the path to the parent of the module file
-				module.name
-			)
+			AvailProjectTemplate.create(module.config)
 		}
 	}
 
+	private val Module.config get() =
+		createProjectPanel.let { panel ->
+			AvailProjectTemplate.Config(
+				projectLocation = moduleFilePath.substringBeforeLast("/"),
+				fileName = name,
+				rootsDir = panel.rootsDirField.input.ifEmpty { "roots" },
+				rootName = panel.rootNameField.input.ifEmpty { name },
+				importStyles = panel.importStyles.isSelected,
+				importTemplates = panel.importTemplates.isSelected,
+				libraryName = panel.libraryNameField.input.ifEmpty { null },
+				selectedLibrary = panel.selectedLibrary,
+				environmentSettings = GlobalEnvironmentSettingsV1()
+			)
+		}
+
 	private val createProjectPanel: CreateAvailProjectPanel =
-		CreateAvailProjectPanel(GlobalEnvironmentSettingsV1())
+		CreateAvailProjectPanel()
 
 	override fun getComponent(): JComponent =
 		createProjectPanel

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -44,48 +44,49 @@ import javax.swing.JComponent
 class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 {
 
-	init
-	{
-		// this listener is called after you choose a location and a name
-		// even though we ask for the Avail module roots and config first
-	  builder.addListener { module ->
-			AvailProjectTemplate.create(module.config)
-		}
-	}
+  init
+  {
+    // this listener is called after you choose a location and a name
+    // even though we ask for the Avail module roots and config first
+    builder.addListener { module ->
+      AvailProjectTemplate.create(module.config)
+    }
+  }
 
-	/**
-	 * Given a Module and the [createProjectPanel] fields,
-	 * create the configuration for the module.
-	 *
-	 * @return The AvailProjectTemplate.Config object representing the configuration.
-	 */
-	private val Module.config get() =
-		createProjectPanel.let { panel ->
-			AvailProjectTemplate.Config(
-				projectLocation = moduleFilePath.substringBeforeLast("/"),
-				fileName = name,
-				rootsDir = panel.rootsDirField.input.ifEmpty { "roots" },
-				rootName = panel.rootNameField.input.ifEmpty { name },
-				importStyles = panel.importStyles.isSelected,
-				importTemplates = panel.importTemplates.isSelected,
-				libraryName = panel.libraryNameField.input.ifEmpty { null },
-				selectedLibrary = panel.selectedLibrary,
-				environmentSettings = GlobalEnvironmentSettingsV1()
-			)
-		}
+  /**
+   * Given a Module and the [createProjectPanel] fields, create the
+   * [AvailProjectTemplate.Config] for the project to be created.
+   */
+  private val Module.config
+    get() =
+      createProjectPanel.let { panel ->
+        AvailProjectTemplate.Config(
+          projectLocation = moduleFilePath.substringBeforeLast("/"),
+          fileName = name,
+          rootsDir = panel.rootsDirField.input.ifEmpty { "roots" },
+          rootName = panel.rootNameField.input.ifEmpty { name },
+          importStyles = panel.importStyles.isSelected,
+          importTemplates = panel.importTemplates.isSelected,
+          libraryName = panel.libraryNameField.input.ifEmpty { null },
+          selectedLibrary = panel.selectedLibrary,
+          environmentSettings = GlobalEnvironmentSettingsV1()
+        )
+      }
 
-	/**
-	 * Represents the panel used to create a new project.
-	 *
-	 * @property createProjectPanel The instance of the CreateAvailProjectPanel class used to display the create project form.
-	 */
-	private val createProjectPanel: CreateAvailProjectPanel =
-		CreateAvailProjectPanel()
+  /**
+   * Represents the panel used to create a new project.
+   *
+   * @property createProjectPanel
+   *   The instance of the CreateAvailProjectPanel class used to display the
+   *   create project form.
+   */
+  private val createProjectPanel: CreateAvailProjectPanel =
+    CreateAvailProjectPanel()
 
-	override fun getComponent(): JComponent =
-		createProjectPanel
+  override fun getComponent(): JComponent =
+    createProjectPanel
 
-	override fun updateDataModel()
-	{
-	}
+  override fun updateDataModel()
+  {
+  }
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -67,7 +67,8 @@ class AvailModuleWizardStep(builder: AvailModuleBuilder) : ModuleWizardStep()
 		get() =
 			createProjectPanel.let { panel ->
 				AvailProjectTemplate.Config(
-					projectLocation = moduleFilePath.substringBeforeLast("/"),
+					projectLocation = moduleFilePath
+						.substringBeforeLast("/"),
 					fileName = name,
 					rootsDir = panel.rootsDirField.input.ifEmpty { "roots" },
 					rootName = panel.rootNameField.input.ifEmpty { name },

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailModuleWizardStep.kt
@@ -40,6 +40,7 @@ import javax.swing.JComponent
  * The [ModuleWizardStep] used to set up a new Avail project.
  *
  * @author Richard Arriaga
+ * @author Raúl Raja
  *
  * @constructor
  * Construct an [AvailModuleWizardStep].

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -269,11 +269,16 @@ object AvailProjectTemplate
   )
 
   /**
-   * Concatenates the given root directory and root name to form a new location directory.
+   * Concatenates the given root directory and root name to form a new
+   * location directory.
    *
-   * @param rootsDir The root directory string.
-   * @param rootName The root name string.
-   * @return The location directory string formed by concatenating rootsDir and rootName.
+   * @param rootsDir
+   *   The root directory string.
+   * @param rootName
+   *   The root name string.
+   * @return
+   *   The location directory string formed by concatenating rootsDir and
+   *   rootName.
    */
   private fun rootsLocationDir(rootsDir: String, rootName: String): String =
     if (rootsDir.isNotEmpty()) "$rootsDir/$rootName"

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -22,6 +22,19 @@ import java.io.File
  */
 object AvailProjectTemplate {
 
+  /**
+   * Represents a configuration for an Avail software project.
+   *
+   * @property projectLocation The location of the project.
+   * @property fileName The name of the configuration file.
+   * @property rootsDir The directory where the project's root files are located.
+   * @property rootName The name of the project's root file.
+   * @property importStyles A flag indicating whether to import styles.
+   * @property importTemplates A flag indicating whether to import templates.
+   * @property libraryName The name of the library used in the project (optional).
+   * @property selectedLibrary The selected library file (optional).
+   * @property environmentSettings The global environment settings for the project.
+   */
   data class Config(
     val projectLocation: String,
     val fileName: String,
@@ -35,7 +48,9 @@ object AvailProjectTemplate {
   )
 
   /**
-   * Create the Avail project.
+   * Creates a new Avail project.
+   *
+   * @param config The configuration for the project.
    */
   @JvmStatic
   fun create (config: Config)
@@ -75,7 +90,8 @@ object AvailProjectTemplate {
   private fun AvailProjectV1.updateBackingProjectFile(
     projectFilePath: String,
     config: Config
-  ) {
+  )
+  {
     if (projectFilePath.isNotEmpty()) {
       // Update the backing project file.
       val writer = JSONWriter.newPrettyPrinterWriter()
@@ -88,7 +104,8 @@ object AvailProjectTemplate {
   private fun AvailProjectV1.configureAvailStdLib(
     config: Config,
     lib: File
-  ) {
+  )
+  {
     val libName = config.libraryName ?: AVAIL_STDLIB_ROOT_NAME
     val libConfigDir = AvailEnvironment.projectRootConfigPath(
       config.fileName, libName, config.projectLocation
@@ -97,10 +114,8 @@ object AvailProjectTemplate {
     val jar = AvailArtifactJar(lib.toURI())
 
     val rootManifest = jar.manifest.roots[AVAIL_STDLIB_ROOT_NAME]
-    var sg =
-      importStyles(config, jar)
-    var tg =
-      importTemplates(config, jar)
+    var sg = importStyles(config, jar)
+    var tg = importTemplates(config, jar)
     val extensions = mutableListOf<String>()
     var description = ""
     rootManifest?.let {
@@ -139,20 +154,24 @@ object AvailProjectTemplate {
   private fun importTemplates(
     config: Config,
     jar: AvailArtifactJar
-  ) = if (config.importTemplates) {
+  ) = if (config.importTemplates)
+  {
     jar.manifest.templatesFor(AVAIL_STDLIB_ROOT_NAME)
       ?: TemplateGroup()
-  } else {
+  } else
+  {
     TemplateGroup()
   }
 
   private fun importStyles(
     config: Config,
     jar: AvailArtifactJar
-  ) = if (config.importStyles) {
+  ) = if (config.importStyles)
+  {
     jar.manifest.stylesFor(AVAIL_STDLIB_ROOT_NAME)
       ?: StylingGroup()
-  } else {
+  } else
+  {
     StylingGroup()
   }
 
@@ -176,10 +195,8 @@ object AvailProjectTemplate {
     TemplateGroup()
   )
 
-  private fun rootsLocationDir(rootsDir: String, rootName: String) = if (rootsDir.isNotEmpty()) {
-    "$rootsDir/$rootName"
-  } else {
-    rootName
-  }
+  private fun rootsLocationDir(rootsDir: String, rootName: String) =
+    if (rootsDir.isNotEmpty()) "$rootsDir/$rootName"
+    else rootName
 
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -275,7 +275,7 @@ object AvailProjectTemplate
    * @param rootName The root name string.
    * @return The location directory string formed by concatenating rootsDir and rootName.
    */
-  private fun rootsLocationDir(rootsDir: String, rootName: String) =
+  private fun rootsLocationDir(rootsDir: String, rootName: String): String =
     if (rootsDir.isNotEmpty()) "$rootsDir/$rootName"
     else rootName
 

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -223,8 +223,8 @@ object AvailProjectTemplate
 	 * @param jar
 	 *   The Avail artifact jar from which to import styles.
 	 * @return
-	 *   The imported [styling group][StylingGroup] if importStyles is enabled in
-	 *   the config object, otherwise an empty styling group.
+	 *   The imported [styling group][StylingGroup] if importStyles is enabled
+	 *   in the config object, otherwise an empty styling group.
 	 */
 	private fun importStyles(
 		config: Config,

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -20,20 +20,30 @@ import java.io.File
  * @author Raul Raja
  *
  */
-object AvailProjectTemplate {
+object AvailProjectTemplate
+{
 
   /**
    * Represents a configuration for an Avail software project.
    *
-   * @property projectLocation The location of the project.
-   * @property fileName The name of the configuration file.
-   * @property rootsDir The directory where the project's root files are located.
-   * @property rootName The name of the project's root file.
-   * @property importStyles A flag indicating whether to import styles.
-   * @property importTemplates A flag indicating whether to import templates.
-   * @property libraryName The name of the library used in the project (optional).
-   * @property selectedLibrary The selected library file (optional).
-   * @property environmentSettings The global environment settings for the project.
+   * @property projectLocation
+   *   The location of the project.
+   * @property fileName
+   *   The name of the configuration file.
+   * @property rootsDir
+   *   The directory where the project's root files are located.
+   * @property rootName
+   *   The name of the project's root file.
+   * @property importStyles
+   *   A flag indicating whether to import styles.
+   * @property importTemplates
+   *   A flag indicating whether to import templates.
+   * @property libraryName
+   *   The name of the library used in the project (optional).
+   * @property selectedLibrary
+   *   The selected library file (optional).
+   * @property environmentSettings
+   *  The global environment settings for the project.
    */
   data class Config(
     val projectLocation: String,
@@ -53,11 +63,14 @@ object AvailProjectTemplate {
    * @param config The configuration for the project.
    */
   @JvmStatic
-  fun create (config: Config)
+  fun create(config: Config)
   {
     val projectFilePath = "${config.projectLocation}/${config.fileName}.json"
     val configPath =
-      AvailEnvironment.projectConfigPath(config.fileName, config.projectLocation)
+      AvailEnvironment.projectConfigPath(
+        config.fileName,
+        config.projectLocation
+      )
     AvailProject.optionallyInitializeConfigDirectory(configPath)
     val localSettings = LocalSettings.from(File(configPath))
     AvailProjectV1(
@@ -75,8 +88,10 @@ object AvailProjectTemplate {
       val rootConfigDir = AvailEnvironment.projectRootConfigPath(
         config.fileName,
         rootName,
-        config.projectLocation)
-      val root = availProjectRoot(rootConfigDir, config, rootName, rootLocationDir)
+        config.projectLocation
+      )
+      val root =
+        availProjectRoot(rootConfigDir, config, rootName, rootLocationDir)
       addRoot(root)
       optionallyInitializeConfigDirectory(rootConfigDir)
       config.selectedLibrary?.let { lib ->
@@ -88,17 +103,21 @@ object AvailProjectTemplate {
   }
 
   /**
-   * Updates the backing project file with the current AvailProjectV1 instance.
+   * Updates the backing project file with the current [AvailProjectV1]
+   * instance.
    *
-   * @param projectFilePath The file path of the backing project file.
-   * @param config The configuration settings.
+   * @param projectFilePath
+   *   The file path of the backing project file.
+   * @param config
+   *   The [configuration][Config] settings.
    */
   private fun AvailProjectV1.updateBackingProjectFile(
     projectFilePath: String,
     config: Config
   )
   {
-    if (projectFilePath.isNotEmpty()) {
+    if (projectFilePath.isNotEmpty())
+    {
       // Update the backing project file.
       val writer = JSONWriter.newPrettyPrinterWriter()
       writeTo(writer)
@@ -110,8 +129,10 @@ object AvailProjectTemplate {
   /**
    * Configures the Avail standard library for the given Avail project.
    *
-   * @param config The configuration settings for the Avail project.
-   * @param lib The file representing the Avail standard library.
+   * @param config
+   *   The [configuration][Config] settings for the Avail project.
+   * @param lib
+   *   The file representing the Avail standard library.
    */
   private fun AvailProjectV1.configureAvailStdLib(
     config: Config,
@@ -164,11 +185,16 @@ object AvailProjectTemplate {
   }
 
   /**
-   * Imports the templates from the given AvailArtifactJar and returns them as a TemplateGroup.
+   * Imports the templates from the given [AvailArtifactJar] and returns them as
+   * a [TemplateGroup].
    *
-   * @param config The configuration object that specifies whether to import templates.
-   * @param jar The AvailArtifactJar from which to import the templates.
-   * @return The imported templates as a TemplateGroup.
+   * @param config
+   *   The [configuration][Config] object that specifies whether to import
+   *   templates.
+   * @param jar
+   *   The [AvailArtifactJar] from which to import the templates.
+   * @return
+   *   The imported templates as a [TemplateGroup].
    */
   private fun importTemplates(
     config: Config,
@@ -177,7 +203,8 @@ object AvailProjectTemplate {
   {
     jar.manifest.templatesFor(AVAIL_STDLIB_ROOT_NAME)
       ?: TemplateGroup()
-  } else
+  }
+  else
   {
     TemplateGroup()
   }
@@ -185,9 +212,13 @@ object AvailProjectTemplate {
   /**
    * Imports the styles for the given Avail artifact jar.
    *
-   * @param config The configuration object containing import options.
-   * @param jar The Avail artifact jar from which to import styles.
-   * @return The imported styling group if importStyles is enabled in the config object, otherwise an empty styling group.
+   * @param config
+   *   The [configuration][Config] object containing import options.
+   * @param jar
+   *   The Avail artifact jar from which to import styles.
+   * @return
+   *   The imported [styling group][StylingGroup] if importStyles is enabled in
+   *   the config object, otherwise an empty styling group.
    */
   private fun importStyles(
     config: Config,
@@ -196,19 +227,26 @@ object AvailProjectTemplate {
   {
     jar.manifest.stylesFor(AVAIL_STDLIB_ROOT_NAME)
       ?: StylingGroup()
-  } else
+  }
+  else
   {
     StylingGroup()
   }
 
   /**
-   * Creates a new AvailProjectRoot object initialized with the provided parameters.
+   * Creates a new [AvailProjectRoot] object initialized with the provided
+   * parameters.
    *
-   * @param rootConfigDir The root configuration directory.
-   * @param config The project configuration.
-   * @param rootName The root name.
-   * @param rootLocationDir The root location directory.
-   * @return The newly created AvailProjectRoot object.
+   * @param rootConfigDir
+   *   The root configuration directory.
+   * @param config
+   *   The project [configuration][Config].
+   * @param rootName
+   *   The [root name][AvailProjectRoot.name].
+   * @param rootLocationDir
+   *   The [root location directory][AvailProjectRoot.location].
+   * @return
+   *   The newly created [AvailProjectRoot] object.
    */
   private fun availProjectRoot(
     rootConfigDir: String,

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -87,6 +87,12 @@ object AvailProjectTemplate {
     }
   }
 
+  /**
+   * Updates the backing project file with the current AvailProjectV1 instance.
+   *
+   * @param projectFilePath The file path of the backing project file.
+   * @param config The configuration settings.
+   */
   private fun AvailProjectV1.updateBackingProjectFile(
     projectFilePath: String,
     config: Config
@@ -101,6 +107,12 @@ object AvailProjectTemplate {
     }
   }
 
+  /**
+   * Configures the Avail standard library for the given Avail project.
+   *
+   * @param config The configuration settings for the Avail project.
+   * @param lib The file representing the Avail standard library.
+   */
   private fun AvailProjectV1.configureAvailStdLib(
     config: Config,
     lib: File
@@ -151,6 +163,13 @@ object AvailProjectTemplate {
     addRoot(stdLib)
   }
 
+  /**
+   * Imports the templates from the given AvailArtifactJar and returns them as a TemplateGroup.
+   *
+   * @param config The configuration object that specifies whether to import templates.
+   * @param jar The AvailArtifactJar from which to import the templates.
+   * @return The imported templates as a TemplateGroup.
+   */
   private fun importTemplates(
     config: Config,
     jar: AvailArtifactJar
@@ -163,6 +182,13 @@ object AvailProjectTemplate {
     TemplateGroup()
   }
 
+  /**
+   * Imports the styles for the given Avail artifact jar.
+   *
+   * @param config The configuration object containing import options.
+   * @param jar The Avail artifact jar from which to import styles.
+   * @return The imported styling group if importStyles is enabled in the config object, otherwise an empty styling group.
+   */
   private fun importStyles(
     config: Config,
     jar: AvailArtifactJar
@@ -175,6 +201,15 @@ object AvailProjectTemplate {
     StylingGroup()
   }
 
+  /**
+   * Creates a new AvailProjectRoot object initialized with the provided parameters.
+   *
+   * @param rootConfigDir The root configuration directory.
+   * @param config The project configuration.
+   * @param rootName The root name.
+   * @param rootLocationDir The root location directory.
+   * @return The newly created AvailProjectRoot object.
+   */
   private fun availProjectRoot(
     rootConfigDir: String,
     config: Config,
@@ -195,6 +230,13 @@ object AvailProjectTemplate {
     TemplateGroup()
   )
 
+  /**
+   * Concatenates the given root directory and root name to form a new location directory.
+   *
+   * @param rootsDir The root directory string.
+   * @param rootName The root name string.
+   * @return The location directory string formed by concatenating rootsDir and rootName.
+   */
   private fun rootsLocationDir(rootsDir: String, rootName: String) =
     if (rootsDir.isNotEmpty()) "$rootsDir/$rootName"
     else rootName

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/AvailProjectTemplate.kt
@@ -23,265 +23,271 @@ import java.io.File
 object AvailProjectTemplate
 {
 
-  /**
-   * Represents a configuration for an Avail software project.
-   *
-   * @property projectLocation
-   *   The location of the project.
-   * @property fileName
-   *   The name of the configuration file.
-   * @property rootsDir
-   *   The directory where the project's root files are located.
-   * @property rootName
-   *   The name of the project's root file.
-   * @property importStyles
-   *   A flag indicating whether to import styles.
-   * @property importTemplates
-   *   A flag indicating whether to import templates.
-   * @property libraryName
-   *   The name of the library used in the project (optional).
-   * @property selectedLibrary
-   *   The selected library file (optional).
-   * @property environmentSettings
-   *  The global environment settings for the project.
-   */
-  data class Config(
-    val projectLocation: String,
-    val fileName: String,
-    val rootsDir: String,
-    val rootName: String,
-    val importStyles: Boolean,
-    val importTemplates: Boolean,
-    val libraryName: String?,
-    val selectedLibrary: File?,
-    val environmentSettings: GlobalEnvironmentSettings
-  )
+	/**
+	 * Represents a configuration for an Avail software project.
+	 *
+	 * @property projectLocation
+	 *   The location of the project.
+	 * @property fileName
+	 *   The name of the configuration file.
+	 * @property rootsDir
+	 *   The directory where the project's root files are located.
+	 * @property rootName
+	 *   The name of the project's root file.
+	 * @property importStyles
+	 *   A flag indicating whether to import styles.
+	 * @property importTemplates
+	 *   A flag indicating whether to import templates.
+	 * @property libraryName
+	 *   The name of the library used in the project (optional).
+	 * @property selectedLibrary
+	 *   The selected library file (optional).
+	 * @property environmentSettings
+	 *  The global environment settings for the project.
+	 */
+	data class Config(
+		val projectLocation: String,
+		val fileName: String,
+		val rootsDir: String,
+		val rootName: String,
+		val importStyles: Boolean,
+		val importTemplates: Boolean,
+		val libraryName: String?,
+		val selectedLibrary: File?,
+		val environmentSettings: GlobalEnvironmentSettings
+	)
 
-  /**
-   * Creates a new Avail project.
-   *
-   * @param config The configuration for the project.
-   */
-  @JvmStatic
-  fun create(config: Config)
-  {
-    val projectFilePath = "${config.projectLocation}/${config.fileName}.json"
-    val configPath =
-      AvailEnvironment.projectConfigPath(
-        config.fileName,
-        config.projectLocation
-      )
-    AvailProject.optionallyInitializeConfigDirectory(configPath)
-    val localSettings = LocalSettings.from(File(configPath))
-    AvailProjectV1(
-      config.fileName,
-      true,
-      AvailRepositories(rootNameInJar = null),
-      localSettings
-    ).apply {
-      File(config.projectLocation).mkdirs()
-      val rootsDir = config.rootsDir
-      val rootName = config.rootName
-      val rootLocationDir = rootsLocationDir(rootsDir, rootName)
-      File("${config.projectLocation}/$rootLocationDir").mkdirs()
+	/**
+	 * Creates a new Avail project.
+	 *
+	 * @param config The configuration for the project.
+	 */
+	@JvmStatic
+	fun create(config: Config)
+	{
+		val projectFilePath =
+			"${config.projectLocation}/${config.fileName}.json"
+		val configPath =
+			AvailEnvironment.projectConfigPath(
+				config.fileName,
+				config.projectLocation
+			)
+		AvailProject.optionallyInitializeConfigDirectory(configPath)
+		val localSettings = LocalSettings.from(File(configPath))
+		AvailProjectV1(
+			config.fileName,
+			true,
+			AvailRepositories(rootNameInJar = null),
+			localSettings
+		).apply {
+			File(config.projectLocation).mkdirs()
+			val rootsDir = config.rootsDir
+			val rootName = config.rootName
+			val rootLocationDir = rootsLocationDir(rootsDir, rootName)
+			File("${config.projectLocation}/$rootLocationDir").mkdirs()
 
-      val rootConfigDir = AvailEnvironment.projectRootConfigPath(
-        config.fileName,
-        rootName,
-        config.projectLocation
-      )
-      val root =
-        availProjectRoot(rootConfigDir, config, rootName, rootLocationDir)
-      addRoot(root)
-      optionallyInitializeConfigDirectory(rootConfigDir)
-      config.selectedLibrary?.let { lib ->
-        configureAvailStdLib(config, lib)
-      }
+			val rootConfigDir = AvailEnvironment.projectRootConfigPath(
+				config.fileName,
+				rootName,
+				config.projectLocation
+			)
+			val root =
+				availProjectRoot(
+					rootConfigDir,
+					config,
+					rootName,
+					rootLocationDir
+				)
+			addRoot(root)
+			optionallyInitializeConfigDirectory(rootConfigDir)
+			config.selectedLibrary?.let { lib ->
+				configureAvailStdLib(config, lib)
+			}
 
-      updateBackingProjectFile(projectFilePath, config)
-    }
-  }
+			updateBackingProjectFile(projectFilePath, config)
+		}
+	}
 
-  /**
-   * Updates the backing project file with the current [AvailProjectV1]
-   * instance.
-   *
-   * @param projectFilePath
-   *   The file path of the backing project file.
-   * @param config
-   *   The [configuration][Config] settings.
-   */
-  private fun AvailProjectV1.updateBackingProjectFile(
-    projectFilePath: String,
-    config: Config
-  )
-  {
-    if (projectFilePath.isNotEmpty())
-    {
-      // Update the backing project file.
-      val writer = JSONWriter.newPrettyPrinterWriter()
-      writeTo(writer)
-      File(projectFilePath).writeText(writer.contents())
-      config.environmentSettings.add(this, projectFilePath)
-    }
-  }
+	/**
+	 * Updates the backing project file with the current [AvailProjectV1]
+	 * instance.
+	 *
+	 * @param projectFilePath
+	 *   The file path of the backing project file.
+	 * @param config
+	 *   The [configuration][Config] settings.
+	 */
+	private fun AvailProjectV1.updateBackingProjectFile(
+		projectFilePath: String,
+		config: Config
+	)
+	{
+		if (projectFilePath.isNotEmpty())
+		{
+			// Update the backing project file.
+			val writer = JSONWriter.newPrettyPrinterWriter()
+			writeTo(writer)
+			File(projectFilePath).writeText(writer.contents())
+			config.environmentSettings.add(this, projectFilePath)
+		}
+	}
 
-  /**
-   * Configures the Avail standard library for the given Avail project.
-   *
-   * @param config
-   *   The [configuration][Config] settings for the Avail project.
-   * @param lib
-   *   The file representing the Avail standard library.
-   */
-  private fun AvailProjectV1.configureAvailStdLib(
-    config: Config,
-    lib: File
-  )
-  {
-    val libName = config.libraryName ?: AVAIL_STDLIB_ROOT_NAME
-    val libConfigDir = AvailEnvironment.projectRootConfigPath(
-      config.fileName, libName, config.projectLocation
-    )
-    optionallyInitializeConfigDirectory(libConfigDir)
-    val jar = AvailArtifactJar(lib.toURI())
+	/**
+	 * Configures the Avail standard library for the given Avail project.
+	 *
+	 * @param config
+	 *   The [configuration][Config] settings for the Avail project.
+	 * @param lib
+	 *   The file representing the Avail standard library.
+	 */
+	private fun AvailProjectV1.configureAvailStdLib(
+		config: Config,
+		lib: File
+	)
+	{
+		val libName = config.libraryName ?: AVAIL_STDLIB_ROOT_NAME
+		val libConfigDir = AvailEnvironment.projectRootConfigPath(
+			config.fileName, libName, config.projectLocation
+		)
+		optionallyInitializeConfigDirectory(libConfigDir)
+		val jar = AvailArtifactJar(lib.toURI())
 
-    val rootManifest = jar.manifest.roots[AVAIL_STDLIB_ROOT_NAME]
-    var sg = importStyles(config, jar)
-    var tg = importTemplates(config, jar)
-    val extensions = mutableListOf<String>()
-    var description = ""
-    rootManifest?.let {
-      sg = it.styles
-      tg = it.templates
-      extensions.addAll(it.availModuleExtensions)
-      description = it.description
-    }
-    val stdLib = AvailProjectRoot(
-      libConfigDir,
-      config.projectLocation,
-      libName,
-      AvailLibraries(
-        "org/availlang/${lib.name}",
-        Scheme.JAR,
-        AVAIL_STDLIB_ROOT_NAME
-      ),
-      LocalSettings(
-        AvailEnvironment.projectRootConfigPath(
-          config.fileName,
-          libName,
-          config.projectLocation
-        )
-      ),
-      sg,
-      tg,
-      extensions
-    )
-    stdLib.description = description
-    stdLib.saveLocalSettingsToDisk()
-    stdLib.saveTemplatesToDisk()
-    stdLib.saveStylesToDisk()
-    addRoot(stdLib)
-  }
+		val rootManifest = jar.manifest.roots[AVAIL_STDLIB_ROOT_NAME]
+		var sg = importStyles(config, jar)
+		var tg = importTemplates(config, jar)
+		val extensions = mutableListOf<String>()
+		var description = ""
+		rootManifest?.let {
+			sg = it.styles
+			tg = it.templates
+			extensions.addAll(it.availModuleExtensions)
+			description = it.description
+		}
+		val stdLib = AvailProjectRoot(
+			libConfigDir,
+			config.projectLocation,
+			libName,
+			AvailLibraries(
+				"org/availlang/${lib.name}",
+				Scheme.JAR,
+				AVAIL_STDLIB_ROOT_NAME
+			),
+			LocalSettings(
+				AvailEnvironment.projectRootConfigPath(
+					config.fileName,
+					libName,
+					config.projectLocation
+				)
+			),
+			sg,
+			tg,
+			extensions
+		)
+		stdLib.description = description
+		stdLib.saveLocalSettingsToDisk()
+		stdLib.saveTemplatesToDisk()
+		stdLib.saveStylesToDisk()
+		addRoot(stdLib)
+	}
 
-  /**
-   * Imports the templates from the given [AvailArtifactJar] and returns them as
-   * a [TemplateGroup].
-   *
-   * @param config
-   *   The [configuration][Config] object that specifies whether to import
-   *   templates.
-   * @param jar
-   *   The [AvailArtifactJar] from which to import the templates.
-   * @return
-   *   The imported templates as a [TemplateGroup].
-   */
-  private fun importTemplates(
-    config: Config,
-    jar: AvailArtifactJar
-  ) = if (config.importTemplates)
-  {
-    jar.manifest.templatesFor(AVAIL_STDLIB_ROOT_NAME)
-      ?: TemplateGroup()
-  }
-  else
-  {
-    TemplateGroup()
-  }
+	/**
+	 * Imports the templates from the given [AvailArtifactJar] and returns them as
+	 * a [TemplateGroup].
+	 *
+	 * @param config
+	 *   The [configuration][Config] object that specifies whether to import
+	 *   templates.
+	 * @param jar
+	 *   The [AvailArtifactJar] from which to import the templates.
+	 * @return
+	 *   The imported templates as a [TemplateGroup].
+	 */
+	private fun importTemplates(
+		config: Config,
+		jar: AvailArtifactJar
+	) = if (config.importTemplates)
+	{
+		jar.manifest.templatesFor(AVAIL_STDLIB_ROOT_NAME)
+			?: TemplateGroup()
+	}
+	else
+	{
+		TemplateGroup()
+	}
 
-  /**
-   * Imports the styles for the given Avail artifact jar.
-   *
-   * @param config
-   *   The [configuration][Config] object containing import options.
-   * @param jar
-   *   The Avail artifact jar from which to import styles.
-   * @return
-   *   The imported [styling group][StylingGroup] if importStyles is enabled in
-   *   the config object, otherwise an empty styling group.
-   */
-  private fun importStyles(
-    config: Config,
-    jar: AvailArtifactJar
-  ) = if (config.importStyles)
-  {
-    jar.manifest.stylesFor(AVAIL_STDLIB_ROOT_NAME)
-      ?: StylingGroup()
-  }
-  else
-  {
-    StylingGroup()
-  }
+	/**
+	 * Imports the styles for the given Avail artifact jar.
+	 *
+	 * @param config
+	 *   The [configuration][Config] object containing import options.
+	 * @param jar
+	 *   The Avail artifact jar from which to import styles.
+	 * @return
+	 *   The imported [styling group][StylingGroup] if importStyles is enabled in
+	 *   the config object, otherwise an empty styling group.
+	 */
+	private fun importStyles(
+		config: Config,
+		jar: AvailArtifactJar
+	) = if (config.importStyles)
+	{
+		jar.manifest.stylesFor(AVAIL_STDLIB_ROOT_NAME)
+			?: StylingGroup()
+	}
+	else
+	{
+		StylingGroup()
+	}
 
-  /**
-   * Creates a new [AvailProjectRoot] object initialized with the provided
-   * parameters.
-   *
-   * @param rootConfigDir
-   *   The root configuration directory.
-   * @param config
-   *   The project [configuration][Config].
-   * @param rootName
-   *   The [root name][AvailProjectRoot.name].
-   * @param rootLocationDir
-   *   The [root location directory][AvailProjectRoot.location].
-   * @return
-   *   The newly created [AvailProjectRoot] object.
-   */
-  private fun availProjectRoot(
-    rootConfigDir: String,
-    config: Config,
-    rootName: String,
-    rootLocationDir: String
-  ) = AvailProjectRoot(
-    rootConfigDir,
-    config.projectLocation,
-    rootName,
-    ProjectHome(
-      rootLocationDir,
-      Scheme.FILE,
-      config.projectLocation,
-      null
-    ),
-    LocalSettings(rootConfigDir),
-    StylingGroup(),
-    TemplateGroup()
-  )
+	/**
+	 * Creates a new [AvailProjectRoot] object initialized with the provided
+	 * parameters.
+	 *
+	 * @param rootConfigDir
+	 *   The root configuration directory.
+	 * @param config
+	 *   The project [configuration][Config].
+	 * @param rootName
+	 *   The [root name][AvailProjectRoot.name].
+	 * @param rootLocationDir
+	 *   The [root location directory][AvailProjectRoot.location].
+	 * @return
+	 *   The newly created [AvailProjectRoot] object.
+	 */
+	private fun availProjectRoot(
+		rootConfigDir: String,
+		config: Config,
+		rootName: String,
+		rootLocationDir: String
+	) = AvailProjectRoot(
+		rootConfigDir,
+		config.projectLocation,
+		rootName,
+		ProjectHome(
+			rootLocationDir,
+			Scheme.FILE,
+			config.projectLocation,
+			null
+		),
+		LocalSettings(rootConfigDir),
+		StylingGroup(),
+		TemplateGroup()
+	)
 
-  /**
-   * Concatenates the given root directory and root name to form a new
-   * location directory.
-   *
-   * @param rootsDir
-   *   The root directory string.
-   * @param rootName
-   *   The root name string.
-   * @return
-   *   The location directory string formed by concatenating rootsDir and
-   *   rootName.
-   */
-  private fun rootsLocationDir(rootsDir: String, rootName: String): String =
-    if (rootsDir.isNotEmpty()) "$rootsDir/$rootName"
-    else rootName
+	/**
+	 * Concatenates the given root directory and root name to form a new
+	 * location directory.
+	 *
+	 * @param rootsDir
+	 *   The root directory string.
+	 * @param rootName
+	 *   The root name string.
+	 * @return
+	 *   The location directory string formed by concatenating rootsDir and
+	 *   rootName.
+	 */
+	private fun rootsLocationDir(rootsDir: String, rootName: String): String =
+		if (rootsDir.isNotEmpty()) "$rootsDir/$rootName"
+		else rootName
 
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -36,9 +36,9 @@ import avail.anvil.components.TextFieldWithLabel
 import avail.anvil.environment.GlobalEnvironmentSettings
 import avail.anvil.environment.availStandardLibraries
 import org.availlang.artifact.environment.project.*
-import java.awt.Dimension
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
+import java.awt.Insets
 import java.io.File
 import javax.swing.JCheckBox
 import javax.swing.JComboBox
@@ -140,56 +140,49 @@ class CreateAvailProjectPanel: JPanel(GridBagLayout())
 
 	init
 	{
-		minimumSize = Dimension(600, 50)
-		preferredSize = Dimension(600, 50)
-		maximumSize = Dimension(600, 50)
-		add(rootNameField,
-			GridBagConstraints().apply {
-				weightx = 1.0
-				fill = GridBagConstraints.HORIZONTAL
-				gridx = 0
-				gridy = 3
-				gridwidth = 2
-			})
-		add(rootsDirField,
-			GridBagConstraints().apply {
-				weightx = 1.0
-				fill = GridBagConstraints.HORIZONTAL
-				gridx = 0
-				gridy = 4
-				gridwidth = 2
-			})
-		add(libraryNameField,
-			GridBagConstraints().apply {
-				weightx = 1.0
-				fill = GridBagConstraints.HORIZONTAL
-				gridx = 0
-				gridy = 5
-				gridwidth = 1
-			})
-		add(libraryPicker,
-			GridBagConstraints().apply {
-				weightx = 1.0
-				fill = GridBagConstraints.HORIZONTAL
-				gridx = 1
-				gridy = 5
-				gridwidth = 1
-			})
-		add(importStyles,
-			GridBagConstraints().apply {
-				weightx = 1.0
-				fill = GridBagConstraints.HORIZONTAL
-				gridx = 1
-				gridy = 6
-				gridwidth = 1
-			})
-		add(importTemplates,
-			GridBagConstraints().apply {
-				weightx = 1.0
-				fill = GridBagConstraints.HORIZONTAL
-				gridx = 1
-				gridy = 7
-				gridwidth = 1
-			})
+		// Create some insets for padding around components
+		val padding = Insets(10, 10, 10, 10) // 10-pixel margins on all sides
+
+		val c = GridBagConstraints()
+		c.insets = padding // apply the insets to the constraints
+		c.fill = GridBagConstraints.HORIZONTAL
+		c.weightx = 1.0
+		c.weighty = 0.0
+		c.gridx = 0
+		c.gridwidth = 2 // Span across two columns for better spacing
+		c.anchor = GridBagConstraints.CENTER // center components
+
+		// The root name field
+		c.gridy = 0
+		add(rootNameField, c)
+
+		// The roots directory field
+		c.gridy = 1
+		add(rootsDirField, c)
+
+		// The library name field
+		c.gridy = 2
+		add(libraryNameField, c)
+
+		// The library picker
+		c.gridy = 3
+		add(libraryPicker, c)
+
+		// The import styles checkbox
+		c.gridy = 4
+		add(importStyles, c)
+
+		// The import templates checkbox
+		c.gridy = 5
+		add(importTemplates, c)
+
+		// Empty panel to push everything else to the top
+		val emptyPanel = JPanel()
+		c.gridy = 6
+		c.weighty = 1.0
+		c.fill = GridBagConstraints.BOTH
+		add(emptyPanel, c)
 	}
+
+
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -34,10 +34,11 @@ package org.availlang.intellij.plugin.module
 
 import avail.anvil.components.ComboBoxWithLabel
 import avail.anvil.components.TextFieldWithLabel
-import avail.anvil.environment.GlobalEnvironmentSettings
 import avail.anvil.environment.availStandardLibraries
 import com.intellij.util.ui.JBUI
-import org.availlang.artifact.environment.project.*
+import org.availlang.artifact.environment.project.AvailProject
+import org.availlang.artifact.environment.project.StylingGroup
+import org.availlang.artifact.environment.project.TemplateGroup
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.io.File
@@ -54,125 +55,125 @@ import javax.swing.JPanel
  */
 class CreateAvailProjectPanel : JPanel(GridBagLayout())
 {
-  /**
-   * The Avail standard libraries available on this machine.
-   */
-  private val standardLibraries =
-    availStandardLibraries.associateBy { it.name }
+	/**
+	 * The Avail standard libraries available on this machine.
+	 */
+	private val standardLibraries =
+		availStandardLibraries.associateBy { it.name }
 
-  /**
-   * The Array of standard library names.
-   */
-  private val standardLibraryNames: Array<String>
-    get() =
-      arrayOf("None") + standardLibraries.keys.toTypedArray()
+	/**
+	 * The Array of standard library names.
+	 */
+	private val standardLibraryNames: Array<String>
+		get() =
+			arrayOf("None") + standardLibraries.keys.toTypedArray()
 
-  /**
-   * The selected Avail standard library to use or `null` if none chosen.
-   */
-  internal var selectedLibrary: File? = null
+	/**
+	 * The selected Avail standard library to use or `null` if none chosen.
+	 */
+	internal var selectedLibrary: File? = null
 
-  /**
-   * The [TextFieldWithLabel] used to set the project name.
-   */
-  internal val rootNameField = TextFieldWithLabel("Create Root Name: ")
+	/**
+	 * The [TextFieldWithLabel] used to set the project name.
+	 */
+	internal val rootNameField = TextFieldWithLabel("Create Root Name: ")
 
-  /**
-   * The [TextFieldWithLabel] used to set the project name.
-   */
-  internal val rootsDirField =
-    TextFieldWithLabel("Roots Directory Name (optional): ").apply {
-      toolTipText =
-        "Leaving blank will create roots at top level of project"
-    }
+	/**
+	 * The [TextFieldWithLabel] used to set the project name.
+	 */
+	internal val rootsDirField =
+		TextFieldWithLabel("Roots Directory Name (optional): ").apply {
+			toolTipText =
+				"Leaving blank will create roots at top level of project"
+		}
 
-  /**
-   * A checkbox to whether or not [StylingGroup] should be imported from the
-   * Avail Standard library.
-   */
-  internal val importStyles = JCheckBox("Import Styles", false).apply {
-    isEnabled = false
-    toolTipText = "Imports styles packaged with standard library"
-  }
+	/**
+	 * A checkbox to whether or not [StylingGroup] should be imported from the
+	 * Avail Standard library.
+	 */
+	internal val importStyles = JCheckBox("Import Styles", false).apply {
+		isEnabled = false
+		toolTipText = "Imports styles packaged with standard library"
+	}
 
-  /**
-   * A checkbox to whether or not [TemplateGroup] should be imported from the
-   * Avail Standard library.
-   */
-  internal val importTemplates = JCheckBox("Import Templates", false).apply {
-    isEnabled = false
-    toolTipText = "Imports templates packaged with standard library"
-  }
+	/**
+	 * A checkbox to whether or not [TemplateGroup] should be imported from the
+	 * Avail Standard library.
+	 */
+	internal val importTemplates = JCheckBox("Import Templates", false).apply {
+		isEnabled = false
+		toolTipText = "Imports templates packaged with standard library"
+	}
 
-  /**
-   * The [TextFieldWithLabel] used to set the standard library root name.
-   */
-  internal val libraryNameField =
-    TextFieldWithLabel("Standard Library Root Name: ").apply {
-      textField.text = "avail"
-    }
+	/**
+	 * The [TextFieldWithLabel] used to set the standard library root name.
+	 */
+	internal val libraryNameField =
+		TextFieldWithLabel("Standard Library Root Name: ").apply {
+			textField.text = "avail"
+		}
 
-  /**
-   * Updated the [JComboBox] used to pick a standard library to add as a root.
-   */
-  private val libraryPicker = ComboBoxWithLabel(
-    label = "Standard Library: ",
-    items = standardLibraryNames,
-    additionalComponents = arrayOf(importStyles, importTemplates)
-  ).apply {
-    comboBox.addActionListener {
-      comboBox.selectedItem?.toString()?.let { key ->
-        standardLibraries[key]?.let { lib ->
-          selectedLibrary = lib
-          importTemplates.isEnabled = true
-          importStyles.isEnabled = true
-        } ?: run {
-          selectedLibrary = null
-          importTemplates.isEnabled = false
-          importTemplates.isSelected = false
-          importStyles.isEnabled = false
-          importStyles.isSelected = false
-        }
-      }
-    }
-  }
+	/**
+	 * Updated the [JComboBox] used to pick a standard library to add as a root.
+	 */
+	private val libraryPicker = ComboBoxWithLabel(
+		label = "Standard Library: ",
+		items = standardLibraryNames,
+		additionalComponents = arrayOf(importStyles, importTemplates)
+	).apply {
+		comboBox.addActionListener {
+			comboBox.selectedItem?.toString()?.let { key ->
+				standardLibraries[key]?.let { lib ->
+					selectedLibrary = lib
+					importTemplates.isEnabled = true
+					importStyles.isEnabled = true
+				} ?: run {
+					selectedLibrary = null
+					importTemplates.isEnabled = false
+					importTemplates.isSelected = false
+					importStyles.isEnabled = false
+					importStyles.isSelected = false
+				}
+			}
+		}
+	}
 
-  init
-  {
-    // Create some insets for padding around components
-    val padding = JBUI.insets(10) // 10-pixel margins on all sides
+	init
+	{
+		// Create some insets for padding around components
+		val padding = JBUI.insets(10) // 10-pixel margins on all sides
 
-    val c = GridBagConstraints()
-    c.insets = padding // apply the insets to the constraints
-    c.fill = GridBagConstraints.HORIZONTAL
-    c.weightx = 1.0
-    c.weighty = 0.0
-    c.gridx = 0
-    c.gridwidth = 2 // Span across two columns for better spacing
-    c.anchor = GridBagConstraints.CENTER // center components
+		val c = GridBagConstraints()
+		c.insets = padding // apply the insets to the constraints
+		c.fill = GridBagConstraints.HORIZONTAL
+		c.weightx = 1.0
+		c.weighty = 0.0
+		c.gridx = 0
+		c.gridwidth = 2 // Span across two columns for better spacing
+		c.anchor = GridBagConstraints.CENTER // center components
 
-    // The root name field
-    c.gridy = 0
-    add(rootNameField, c)
+		// The root name field
+		c.gridy = 0
+		add(rootNameField, c)
 
-    // The roots directory field
-    c.gridy = 1
-    add(rootsDirField, c)
+		// The roots directory field
+		c.gridy = 1
+		add(rootsDirField, c)
 
-    // The library name field
-    c.gridy = 2
-    add(libraryNameField, c)
+		// The library name field
+		c.gridy = 2
+		add(libraryNameField, c)
 
-    // The library picker
-    c.gridy = 3
-    add(libraryPicker, c)
+		// The library picker
+		c.gridy = 3
+		add(libraryPicker, c)
 
-    // Empty panel to push everything else to the top
-    val emptyPanel = JPanel()
-    c.gridy = 4
-    c.weighty = 1.0
-    c.fill = GridBagConstraints.BOTH
-    add(emptyPanel, c)
-  }
+		// Empty panel to push everything else to the top
+		val emptyPanel = JPanel()
+		c.gridy = 4
+		c.weighty = 1.0
+		c.fill = GridBagConstraints.BOTH
+		add(emptyPanel, c)
+	}
 
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -1,0 +1,324 @@
+/*
+ * CreateProjectPanel.kt
+ * Copyright © 1993-2023, The Avail Foundation, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of the contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.availlang.intellij.plugin.module
+
+import avail.anvil.components.TextFieldWithLabel
+import avail.anvil.environment.AVAIL_STDLIB_ROOT_NAME
+import avail.anvil.environment.GlobalEnvironmentSettings
+import avail.anvil.environment.availStandardLibraries
+import org.availlang.artifact.environment.AvailEnvironment
+import org.availlang.artifact.environment.location.AvailLibraries
+import org.availlang.artifact.environment.location.AvailRepositories
+import org.availlang.artifact.environment.location.ProjectHome
+import org.availlang.artifact.environment.location.Scheme
+import org.availlang.artifact.environment.project.*
+import org.availlang.artifact.jar.AvailArtifactJar
+import org.availlang.json.JSONWriter
+import java.awt.Dimension
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.io.File
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JPanel
+
+/**
+ * A [JPanel] used to create a new [AvailProject].
+ *
+ * Adapted to IDEA from [avail.anvil.manager.CreateProjectPanel]
+ *
+ * @author Raul Raja
+ *
+ * @property config
+ *   The [GlobalEnvironmentSettings] for this machine.
+ * @property onCreate
+ *   The function that accepts the newly created [AvailProject].
+ * @property onCancel
+ *   The function to call if creating a new project is canceled.
+ */
+class CreateAvailProjectPanel constructor(
+	internal val config: GlobalEnvironmentSettings
+): JPanel(GridBagLayout())
+{
+	/**
+	 * The Avail standard libraries available on this machine.
+	 */
+	private val standardLibraries =
+		availStandardLibraries.associateBy { it.name }
+
+	/**
+	 * The Array of standard library names.
+	 */
+	private val standardLibraryNames: Array<String> get() =
+		arrayOf("None") + standardLibraries.keys.toTypedArray()
+
+	/**
+	 * The selected Avail standard library to use or `null` if none chosen.
+	 */
+	private var selectedLibrary: File? = null
+
+	/**
+	 * Create the Avail project.
+	 */
+	fun create (projLocation: String, fileName: String)
+	{
+		val projectFilePath = "$projLocation/$fileName.json"
+		val configPath =
+			AvailEnvironment.projectConfigPath(fileName, projLocation)
+		AvailProject.optionallyInitializeConfigDirectory(configPath)
+		val localSettings = LocalSettings.from(File(configPath))
+		AvailProjectV1(
+			fileName,
+			true,
+			AvailRepositories(rootNameInJar = null),
+			localSettings
+		).apply {
+			File(projLocation).mkdirs()
+			val rootsDir = rootsDirField.textField.text
+			val rootName = rootNameField.textField.text
+			val rootLocationDir =
+				if (rootsDir.isNotEmpty())
+				{
+					"$rootsDir/$rootName"
+				}
+				else
+				{
+					rootName
+				}
+			File("$projLocation/$rootLocationDir").mkdirs()
+
+			val rootConfigDir = AvailEnvironment.projectRootConfigPath(
+				fileName,
+				rootName,
+				projLocation)
+			val root = AvailProjectRoot(
+				rootConfigDir,
+				projLocation,
+				rootName,
+				ProjectHome(
+					rootLocationDir,
+					Scheme.FILE,
+					projLocation,
+					null),
+					LocalSettings(rootConfigDir),
+					StylingGroup(),
+					TemplateGroup())
+			addRoot(root)
+			optionallyInitializeConfigDirectory(rootConfigDir)
+			selectedLibrary?.let { lib ->
+				val libName =
+					libraryNameField.input.ifEmpty { AVAIL_STDLIB_ROOT_NAME }
+				val libConfigDir = AvailEnvironment.projectRootConfigPath(
+					fileName, libName, projLocation)
+				optionallyInitializeConfigDirectory(libConfigDir)
+				val jar = AvailArtifactJar(lib.toURI())
+
+				val rootManifest = jar.manifest.roots[AVAIL_STDLIB_ROOT_NAME]
+				var sg =
+					if(importStyles.isSelected)
+					{
+						jar.manifest.stylesFor(AVAIL_STDLIB_ROOT_NAME)
+							?: StylingGroup()
+					}
+					else
+					{
+						StylingGroup()
+					}
+				var tg =
+					if(importTemplates.isSelected)
+					{
+						jar.manifest.templatesFor(AVAIL_STDLIB_ROOT_NAME)
+							?: TemplateGroup()
+					}
+					else
+					{
+						TemplateGroup()
+					}
+				val extensions = mutableListOf<String>()
+				var description = ""
+				rootManifest?.let {
+					sg = it.styles
+					tg = it.templates
+					extensions.addAll(it.availModuleExtensions)
+					description = it.description
+				}
+				val stdLib = AvailProjectRoot(
+					libConfigDir,
+					projLocation,
+					libName,
+					AvailLibraries(
+					"org/availlang/${lib.name}",
+						Scheme.JAR,
+						AVAIL_STDLIB_ROOT_NAME),
+					LocalSettings(
+						AvailEnvironment.projectRootConfigPath(
+							fileName,
+							libName,
+							projLocation)),
+					sg,
+					tg,
+					extensions)
+				stdLib.description = description
+				stdLib.saveLocalSettingsToDisk()
+				stdLib.saveTemplatesToDisk()
+				stdLib.saveStylesToDisk()
+				addRoot(stdLib)
+			}
+
+			if (projectFilePath.isNotEmpty())
+			{
+				// Update the backing project file.
+				val writer = JSONWriter.newPrettyPrinterWriter()
+				writeTo(writer)
+				File(projectFilePath).writeText(writer.contents())
+				config.add(this, projectFilePath)
+			}
+		}
+	}
+
+	/**
+	 * The [TextFieldWithLabel] used to set the project name.
+	 */
+	private val rootNameField = TextFieldWithLabel("Create Root Name: ")
+
+	/**
+	 * The [TextFieldWithLabel] used to set the project name.
+	 */
+	private val rootsDirField =
+		TextFieldWithLabel("Roots Directory Name (optional): ").apply {
+			toolTipText =
+				"Leaving blank will create roots at top level of project"
+		}
+
+	/**
+	 * A checkbox to whether or not [StylingGroup] should be imported from the
+	 * Avail Standard library.
+	 */
+	val importStyles = JCheckBox("Import Styles", false).apply {
+		isEnabled = false
+		toolTipText = "Imports styles packaged with standard library"
+	}
+
+	/**
+	 * A checkbox to whether or not [TemplateGroup] should be imported from the
+	 * Avail Standard library.
+	 */
+	val importTemplates = JCheckBox("Import Templates", false).apply {
+		isEnabled = false
+		toolTipText = "Imports templates packaged with standard library"
+	}
+
+	/**
+	 * The [TextFieldWithLabel] used to set the standard library root name.
+	 */
+	private val libraryNameField =
+		TextFieldWithLabel("Standard Library Root Name: ").apply {
+			textField.text = "avail"
+		}
+
+	/**
+	 * Updated the [JComboBox] used to pick a standard library to add as a root.
+	 */
+	private val libraryPicker = JComboBox(standardLibraryNames).apply {
+		addActionListener {
+			selectedItem?.toString()?.let { key ->
+				standardLibraries[key]?.let { lib ->
+					selectedLibrary = lib
+					importTemplates.isEnabled = true
+					importStyles.isEnabled = true
+				} ?: run {
+					selectedLibrary = null
+					importTemplates.isEnabled = false
+					importTemplates.isSelected = false
+					importStyles.isEnabled = false
+					importStyles.isSelected = false
+				}
+			}
+		}
+	}
+
+	init
+	{
+		minimumSize = Dimension(600, 50)
+		preferredSize = Dimension(600, 50)
+		maximumSize = Dimension(600, 50)
+		add(rootNameField,
+			GridBagConstraints().apply {
+				weightx = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = 0
+				gridy = 3
+				gridwidth = 2
+			})
+		add(rootsDirField,
+			GridBagConstraints().apply {
+				weightx = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = 0
+				gridy = 4
+				gridwidth = 2
+			})
+		add(libraryNameField,
+			GridBagConstraints().apply {
+				weightx = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = 0
+				gridy = 5
+				gridwidth = 1
+			})
+		add(libraryPicker,
+			GridBagConstraints().apply {
+				weightx = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = 1
+				gridy = 5
+				gridwidth = 1
+			})
+		add(importStyles,
+			GridBagConstraints().apply {
+				weightx = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = 1
+				gridy = 6
+				gridwidth = 1
+			})
+		add(importTemplates,
+			GridBagConstraints().apply {
+				weightx = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = 1
+				gridy = 7
+				gridwidth = 1
+			})
+	}
+}

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -50,14 +50,7 @@ import javax.swing.JPanel
  *
  * Adapted to IDEA from [avail.anvil.manager.CreateProjectPanel]
  *
- * @author Raul Raja
- *
- * @property config
- *   The [GlobalEnvironmentSettings] for this machine.
- * @property onCreate
- *   The function that accepts the newly created [AvailProject].
- * @property onCancel
- *   The function to call if creating a new project is canceled.
+ * @author Raúl Raja
  */
 class CreateAvailProjectPanel : JPanel(GridBagLayout())
 {

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -33,17 +33,9 @@
 package org.availlang.intellij.plugin.module
 
 import avail.anvil.components.TextFieldWithLabel
-import avail.anvil.environment.AVAIL_STDLIB_ROOT_NAME
 import avail.anvil.environment.GlobalEnvironmentSettings
 import avail.anvil.environment.availStandardLibraries
-import org.availlang.artifact.environment.AvailEnvironment
-import org.availlang.artifact.environment.location.AvailLibraries
-import org.availlang.artifact.environment.location.AvailRepositories
-import org.availlang.artifact.environment.location.ProjectHome
-import org.availlang.artifact.environment.location.Scheme
 import org.availlang.artifact.environment.project.*
-import org.availlang.artifact.jar.AvailArtifactJar
-import org.availlang.json.JSONWriter
 import java.awt.Dimension
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -66,9 +58,7 @@ import javax.swing.JPanel
  * @property onCancel
  *   The function to call if creating a new project is canceled.
  */
-class CreateAvailProjectPanel constructor(
-	internal val config: GlobalEnvironmentSettings
-): JPanel(GridBagLayout())
+class CreateAvailProjectPanel: JPanel(GridBagLayout())
 {
 	/**
 	 * The Avail standard libraries available on this machine.
@@ -85,136 +75,17 @@ class CreateAvailProjectPanel constructor(
 	/**
 	 * The selected Avail standard library to use or `null` if none chosen.
 	 */
-	private var selectedLibrary: File? = null
-
-	/**
-	 * Create the Avail project.
-	 */
-	fun create (projLocation: String, fileName: String)
-	{
-		val projectFilePath = "$projLocation/$fileName.json"
-		val configPath =
-			AvailEnvironment.projectConfigPath(fileName, projLocation)
-		AvailProject.optionallyInitializeConfigDirectory(configPath)
-		val localSettings = LocalSettings.from(File(configPath))
-		AvailProjectV1(
-			fileName,
-			true,
-			AvailRepositories(rootNameInJar = null),
-			localSettings
-		).apply {
-			File(projLocation).mkdirs()
-			val rootsDir = rootsDirField.textField.text
-			val rootName = rootNameField.textField.text
-			val rootLocationDir =
-				if (rootsDir.isNotEmpty())
-				{
-					"$rootsDir/$rootName"
-				}
-				else
-				{
-					rootName
-				}
-			File("$projLocation/$rootLocationDir").mkdirs()
-
-			val rootConfigDir = AvailEnvironment.projectRootConfigPath(
-				fileName,
-				rootName,
-				projLocation)
-			val root = AvailProjectRoot(
-				rootConfigDir,
-				projLocation,
-				rootName,
-				ProjectHome(
-					rootLocationDir,
-					Scheme.FILE,
-					projLocation,
-					null),
-					LocalSettings(rootConfigDir),
-					StylingGroup(),
-					TemplateGroup())
-			addRoot(root)
-			optionallyInitializeConfigDirectory(rootConfigDir)
-			selectedLibrary?.let { lib ->
-				val libName =
-					libraryNameField.input.ifEmpty { AVAIL_STDLIB_ROOT_NAME }
-				val libConfigDir = AvailEnvironment.projectRootConfigPath(
-					fileName, libName, projLocation)
-				optionallyInitializeConfigDirectory(libConfigDir)
-				val jar = AvailArtifactJar(lib.toURI())
-
-				val rootManifest = jar.manifest.roots[AVAIL_STDLIB_ROOT_NAME]
-				var sg =
-					if(importStyles.isSelected)
-					{
-						jar.manifest.stylesFor(AVAIL_STDLIB_ROOT_NAME)
-							?: StylingGroup()
-					}
-					else
-					{
-						StylingGroup()
-					}
-				var tg =
-					if(importTemplates.isSelected)
-					{
-						jar.manifest.templatesFor(AVAIL_STDLIB_ROOT_NAME)
-							?: TemplateGroup()
-					}
-					else
-					{
-						TemplateGroup()
-					}
-				val extensions = mutableListOf<String>()
-				var description = ""
-				rootManifest?.let {
-					sg = it.styles
-					tg = it.templates
-					extensions.addAll(it.availModuleExtensions)
-					description = it.description
-				}
-				val stdLib = AvailProjectRoot(
-					libConfigDir,
-					projLocation,
-					libName,
-					AvailLibraries(
-					"org/availlang/${lib.name}",
-						Scheme.JAR,
-						AVAIL_STDLIB_ROOT_NAME),
-					LocalSettings(
-						AvailEnvironment.projectRootConfigPath(
-							fileName,
-							libName,
-							projLocation)),
-					sg,
-					tg,
-					extensions)
-				stdLib.description = description
-				stdLib.saveLocalSettingsToDisk()
-				stdLib.saveTemplatesToDisk()
-				stdLib.saveStylesToDisk()
-				addRoot(stdLib)
-			}
-
-			if (projectFilePath.isNotEmpty())
-			{
-				// Update the backing project file.
-				val writer = JSONWriter.newPrettyPrinterWriter()
-				writeTo(writer)
-				File(projectFilePath).writeText(writer.contents())
-				config.add(this, projectFilePath)
-			}
-		}
-	}
+	internal var selectedLibrary: File? = null
 
 	/**
 	 * The [TextFieldWithLabel] used to set the project name.
 	 */
-	private val rootNameField = TextFieldWithLabel("Create Root Name: ")
+	internal val rootNameField = TextFieldWithLabel("Create Root Name: ")
 
 	/**
 	 * The [TextFieldWithLabel] used to set the project name.
 	 */
-	private val rootsDirField =
+	internal val rootsDirField =
 		TextFieldWithLabel("Roots Directory Name (optional): ").apply {
 			toolTipText =
 				"Leaving blank will create roots at top level of project"
@@ -224,7 +95,7 @@ class CreateAvailProjectPanel constructor(
 	 * A checkbox to whether or not [StylingGroup] should be imported from the
 	 * Avail Standard library.
 	 */
-	val importStyles = JCheckBox("Import Styles", false).apply {
+	internal val importStyles = JCheckBox("Import Styles", false).apply {
 		isEnabled = false
 		toolTipText = "Imports styles packaged with standard library"
 	}
@@ -233,7 +104,7 @@ class CreateAvailProjectPanel constructor(
 	 * A checkbox to whether or not [TemplateGroup] should be imported from the
 	 * Avail Standard library.
 	 */
-	val importTemplates = JCheckBox("Import Templates", false).apply {
+	internal val importTemplates = JCheckBox("Import Templates", false).apply {
 		isEnabled = false
 		toolTipText = "Imports templates packaged with standard library"
 	}
@@ -241,7 +112,7 @@ class CreateAvailProjectPanel constructor(
 	/**
 	 * The [TextFieldWithLabel] used to set the standard library root name.
 	 */
-	private val libraryNameField =
+	internal val libraryNameField =
 		TextFieldWithLabel("Standard Library Root Name: ").apply {
 			textField.text = "avail"
 		}

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -59,127 +59,127 @@ import javax.swing.JPanel
  * @property onCancel
  *   The function to call if creating a new project is canceled.
  */
-class CreateAvailProjectPanel: JPanel(GridBagLayout())
+class CreateAvailProjectPanel : JPanel(GridBagLayout())
 {
-	/**
-	 * The Avail standard libraries available on this machine.
-	 */
-	private val standardLibraries =
-		availStandardLibraries.associateBy { it.name }
+  /**
+   * The Avail standard libraries available on this machine.
+   */
+  private val standardLibraries =
+    availStandardLibraries.associateBy { it.name }
 
-	/**
-	 * The Array of standard library names.
-	 */
-	private val standardLibraryNames: Array<String> get() =
-		arrayOf("None") + standardLibraries.keys.toTypedArray()
+  /**
+   * The Array of standard library names.
+   */
+  private val standardLibraryNames: Array<String>
+    get() =
+      arrayOf("None") + standardLibraries.keys.toTypedArray()
 
-	/**
-	 * The selected Avail standard library to use or `null` if none chosen.
-	 */
-	internal var selectedLibrary: File? = null
+  /**
+   * The selected Avail standard library to use or `null` if none chosen.
+   */
+  internal var selectedLibrary: File? = null
 
-	/**
-	 * The [TextFieldWithLabel] used to set the project name.
-	 */
-	internal val rootNameField = TextFieldWithLabel("Create Root Name: ")
+  /**
+   * The [TextFieldWithLabel] used to set the project name.
+   */
+  internal val rootNameField = TextFieldWithLabel("Create Root Name: ")
 
-	/**
-	 * The [TextFieldWithLabel] used to set the project name.
-	 */
-	internal val rootsDirField =
-		TextFieldWithLabel("Roots Directory Name (optional): ").apply {
-			toolTipText =
-				"Leaving blank will create roots at top level of project"
-		}
+  /**
+   * The [TextFieldWithLabel] used to set the project name.
+   */
+  internal val rootsDirField =
+    TextFieldWithLabel("Roots Directory Name (optional): ").apply {
+      toolTipText =
+        "Leaving blank will create roots at top level of project"
+    }
 
-	/**
-	 * A checkbox to whether or not [StylingGroup] should be imported from the
-	 * Avail Standard library.
-	 */
-	internal val importStyles = JCheckBox("Import Styles", false).apply {
-		isEnabled = false
-		toolTipText = "Imports styles packaged with standard library"
-	}
+  /**
+   * A checkbox to whether or not [StylingGroup] should be imported from the
+   * Avail Standard library.
+   */
+  internal val importStyles = JCheckBox("Import Styles", false).apply {
+    isEnabled = false
+    toolTipText = "Imports styles packaged with standard library"
+  }
 
-	/**
-	 * A checkbox to whether or not [TemplateGroup] should be imported from the
-	 * Avail Standard library.
-	 */
-	internal val importTemplates = JCheckBox("Import Templates", false).apply {
-		isEnabled = false
-		toolTipText = "Imports templates packaged with standard library"
-	}
+  /**
+   * A checkbox to whether or not [TemplateGroup] should be imported from the
+   * Avail Standard library.
+   */
+  internal val importTemplates = JCheckBox("Import Templates", false).apply {
+    isEnabled = false
+    toolTipText = "Imports templates packaged with standard library"
+  }
 
-	/**
-	 * The [TextFieldWithLabel] used to set the standard library root name.
-	 */
-	internal val libraryNameField =
-		TextFieldWithLabel("Standard Library Root Name: ").apply {
-			textField.text = "avail"
-		}
+  /**
+   * The [TextFieldWithLabel] used to set the standard library root name.
+   */
+  internal val libraryNameField =
+    TextFieldWithLabel("Standard Library Root Name: ").apply {
+      textField.text = "avail"
+    }
 
-	/**
-	 * Updated the [JComboBox] used to pick a standard library to add as a root.
-	 */
-	private val libraryPicker = ComboBoxWithLabel(
-		label = "Standard Library: ",
-		items = standardLibraryNames,
-		additionalComponents = arrayOf(importStyles, importTemplates)
-	).apply {
-		comboBox.addActionListener {
-			comboBox.selectedItem?.toString()?.let { key ->
-				standardLibraries[key]?.let { lib ->
-					selectedLibrary = lib
-					importTemplates.isEnabled = true
-					importStyles.isEnabled = true
-				} ?: run {
-					selectedLibrary = null
-					importTemplates.isEnabled = false
-					importTemplates.isSelected = false
-					importStyles.isEnabled = false
-					importStyles.isSelected = false
-				}
-			}
-		}
-	}
+  /**
+   * Updated the [JComboBox] used to pick a standard library to add as a root.
+   */
+  private val libraryPicker = ComboBoxWithLabel(
+    label = "Standard Library: ",
+    items = standardLibraryNames,
+    additionalComponents = arrayOf(importStyles, importTemplates)
+  ).apply {
+    comboBox.addActionListener {
+      comboBox.selectedItem?.toString()?.let { key ->
+        standardLibraries[key]?.let { lib ->
+          selectedLibrary = lib
+          importTemplates.isEnabled = true
+          importStyles.isEnabled = true
+        } ?: run {
+          selectedLibrary = null
+          importTemplates.isEnabled = false
+          importTemplates.isSelected = false
+          importStyles.isEnabled = false
+          importStyles.isSelected = false
+        }
+      }
+    }
+  }
 
-	init
-	{
-		// Create some insets for padding around components
-		val padding = JBUI.insets(10) // 10-pixel margins on all sides
+  init
+  {
+    // Create some insets for padding around components
+    val padding = JBUI.insets(10) // 10-pixel margins on all sides
 
-		val c = GridBagConstraints()
-		c.insets = padding // apply the insets to the constraints
-		c.fill = GridBagConstraints.HORIZONTAL
-		c.weightx = 1.0
-		c.weighty = 0.0
-		c.gridx = 0
-		c.gridwidth = 2 // Span across two columns for better spacing
-		c.anchor = GridBagConstraints.CENTER // center components
+    val c = GridBagConstraints()
+    c.insets = padding // apply the insets to the constraints
+    c.fill = GridBagConstraints.HORIZONTAL
+    c.weightx = 1.0
+    c.weighty = 0.0
+    c.gridx = 0
+    c.gridwidth = 2 // Span across two columns for better spacing
+    c.anchor = GridBagConstraints.CENTER // center components
 
-		// The root name field
-		c.gridy = 0
-		add(rootNameField, c)
+    // The root name field
+    c.gridy = 0
+    add(rootNameField, c)
 
-		// The roots directory field
-		c.gridy = 1
-		add(rootsDirField, c)
+    // The roots directory field
+    c.gridy = 1
+    add(rootsDirField, c)
 
-		// The library name field
-		c.gridy = 2
-		add(libraryNameField, c)
+    // The library name field
+    c.gridy = 2
+    add(libraryNameField, c)
 
-		// The library picker
-		c.gridy = 3
-		add(libraryPicker, c)
+    // The library picker
+    c.gridy = 3
+    add(libraryPicker, c)
 
-		// Empty panel to push everything else to the top
-		val emptyPanel = JPanel()
-		c.gridy = 4
-		c.weighty = 1.0
-		c.fill = GridBagConstraints.BOTH
-		add(emptyPanel, c)
-	}
-
+    // Empty panel to push everything else to the top
+    val emptyPanel = JPanel()
+    c.gridy = 4
+    c.weighty = 1.0
+    c.fill = GridBagConstraints.BOTH
+    add(emptyPanel, c)
+  }
 
 }

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -91,19 +91,21 @@ class CreateAvailProjectPanel : JPanel(GridBagLayout())
 	 * A checkbox to whether or not [StylingGroup] should be imported from the
 	 * Avail Standard library.
 	 */
-	internal val importStyles = JCheckBox("Import Styles", false).apply {
-		isEnabled = false
-		toolTipText = "Imports styles packaged with standard library"
-	}
+	internal val importStyles =
+		JCheckBox("Import Styles", false).apply {
+			isEnabled = false
+			toolTipText = "Imports styles packaged with standard library"
+		}
 
 	/**
 	 * A checkbox to whether or not [TemplateGroup] should be imported from the
 	 * Avail Standard library.
 	 */
-	internal val importTemplates = JCheckBox("Import Templates", false).apply {
-		isEnabled = false
-		toolTipText = "Imports templates packaged with standard library"
-	}
+	internal val importTemplates =
+		JCheckBox("Import Templates", false).apply {
+			isEnabled = false
+			toolTipText = "Imports templates packaged with standard library"
+		}
 
 	/**
 	 * The [TextFieldWithLabel] used to set the standard library root name.

--- a/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
+++ b/avail-intellij-plugin/src/main/kotlin/org/availlang/intellij/plugin/module/CreateAvailProjectPanel.kt
@@ -32,13 +32,14 @@
 
 package org.availlang.intellij.plugin.module
 
+import avail.anvil.components.ComboBoxWithLabel
 import avail.anvil.components.TextFieldWithLabel
 import avail.anvil.environment.GlobalEnvironmentSettings
 import avail.anvil.environment.availStandardLibraries
+import com.intellij.util.ui.JBUI
 import org.availlang.artifact.environment.project.*
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
-import java.awt.Insets
 import java.io.File
 import javax.swing.JCheckBox
 import javax.swing.JComboBox
@@ -120,9 +121,13 @@ class CreateAvailProjectPanel: JPanel(GridBagLayout())
 	/**
 	 * Updated the [JComboBox] used to pick a standard library to add as a root.
 	 */
-	private val libraryPicker = JComboBox(standardLibraryNames).apply {
-		addActionListener {
-			selectedItem?.toString()?.let { key ->
+	private val libraryPicker = ComboBoxWithLabel(
+		label = "Standard Library: ",
+		items = standardLibraryNames,
+		additionalComponents = arrayOf(importStyles, importTemplates)
+	).apply {
+		comboBox.addActionListener {
+			comboBox.selectedItem?.toString()?.let { key ->
 				standardLibraries[key]?.let { lib ->
 					selectedLibrary = lib
 					importTemplates.isEnabled = true
@@ -141,7 +146,7 @@ class CreateAvailProjectPanel: JPanel(GridBagLayout())
 	init
 	{
 		// Create some insets for padding around components
-		val padding = Insets(10, 10, 10, 10) // 10-pixel margins on all sides
+		val padding = JBUI.insets(10) // 10-pixel margins on all sides
 
 		val c = GridBagConstraints()
 		c.insets = padding // apply the insets to the constraints
@@ -168,17 +173,9 @@ class CreateAvailProjectPanel: JPanel(GridBagLayout())
 		c.gridy = 3
 		add(libraryPicker, c)
 
-		// The import styles checkbox
-		c.gridy = 4
-		add(importStyles, c)
-
-		// The import templates checkbox
-		c.gridy = 5
-		add(importTemplates, c)
-
 		// Empty panel to push everything else to the top
 		val emptyPanel = JPanel()
-		c.gridy = 6
+		c.gridy = 4
 		c.weighty = 1.0
 		c.fill = GridBagConstraints.BOTH
 		add(emptyPanel, c)

--- a/avail/.idea/codeStyles/codeStyleConfig.xml
+++ b/avail/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Todd L Smith" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/avail/src/main/kotlin/avail/anvil/components/ComboBoxWithLabel.kt
+++ b/avail/src/main/kotlin/avail/anvil/components/ComboBoxWithLabel.kt
@@ -43,12 +43,18 @@ import javax.swing.border.Border
  * A [JPanel] with a [GridBagLayout] that places a [JLabel] to the left of a
  * [JComboBox].
  *
- * @param label The text for the [JLabel] to the left of the [JComboBox].
- * @param items The items to be displayed in the [JComboBox].
- * @param additionalComponents Additional components to be added to the bottom of the [JComboBox].
- * @param emptySpaceRight Optional space to the right of the [JComboBox].
- * @param emptySpaceLeft Optional space to the left of the [JLabel].
- * @param panelBorder The border surrounding the [JPanel].
+ * @param label
+ *   The text for the [JLabel] to the left of the [JComboBox].
+ * @param items
+ *   The items to be displayed in the [JComboBox].
+ * @param additionalComponents
+ *   Additional components to be added to the bottom of the [JComboBox].
+ * @param emptySpaceRight
+ *   Optional space to the right of the [JComboBox].
+ * @param emptySpaceLeft
+ *   Optional space to the left of the [JLabel].
+ * @param panelBorder
+ *   The border surrounding the [JPanel].
  */
 class ComboBoxWithLabel<T>(
 	label: String,
@@ -115,7 +121,8 @@ class ComboBoxWithLabel<T>(
 					gridx = 0  // Align with the start of the combo box
 					gridy = index + 1  // Position under the combo box
 					gridwidth = 2  // Span across both label and combo box
-					insets = Insets(10, 0, 0, 0)  // Add some top margin for better spacing
+					// Add some top margin for better spacing
+					insets = Insets(10, 0, 0, 0)
 				})
 		}
 	}

--- a/avail/src/main/kotlin/avail/anvil/components/ComboBoxWithLabel.kt
+++ b/avail/src/main/kotlin/avail/anvil/components/ComboBoxWithLabel.kt
@@ -1,0 +1,137 @@
+/*
+ * ComboBoxWithLabel.kt
+ * Copyright © 1993-2022, The Avail Foundation, LLC.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of the copyright holder nor the names of the contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package avail.anvil.components
+
+import java.awt.Dimension
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.*
+import javax.swing.border.Border
+
+/**
+ * A [JPanel] with a [GridBagLayout] that places a [JLabel] to the left of a
+ * [JComboBox].
+ *
+ * @param label The text for the [JLabel] to the left of the [JComboBox].
+ * @param items The items to be displayed in the [JComboBox].
+ * @param additionalComponents Additional components to be added to the bottom of the [JComboBox].
+ * @param emptySpaceRight Optional space to the right of the [JComboBox].
+ * @param emptySpaceLeft Optional space to the left of the [JLabel].
+ * @param panelBorder The border surrounding the [JPanel].
+ */
+class ComboBoxWithLabel<T>(
+	label: String,
+	items: Array<T>,
+	additionalComponents: Array<JComponent> = emptyArray(),
+	emptySpaceRight: Double? = null,
+	emptySpaceLeft: Double? = null,
+	panelBorder: Border = BorderFactory.createEmptyBorder(10,10,10,10)
+): JPanel(GridBagLayout())
+{
+
+	/**
+	 * The next column for the layout.
+	 */
+	private var nextColumn = 0
+
+	init {
+		emptySpaceLeft?.let {
+			add(
+				Box.createRigidArea(Dimension(1, 1)),
+				GridBagConstraints().apply {
+					gridx = nextColumn++
+					gridy = 0
+					gridheight = 2
+					weightx = it
+				})
+		}
+	}
+
+	/**
+	 * The [JLabel] to the left of the [JComboBox].
+	 */
+	val label = JLabel(label).apply {
+		this@ComboBoxWithLabel.add(
+			this,
+			GridBagConstraints().apply {
+				gridx = nextColumn++
+				gridy = 0
+				gridwidth = 1
+			})
+	}
+
+	/**
+	 * The [JComboBox] that displays the selectable items.
+	 */
+	val comboBox: JComboBox<T> = JComboBox(items).apply {
+		this@ComboBoxWithLabel.add(
+			this,
+			GridBagConstraints().apply {
+				weightx = 0.75
+				weighty = 1.0
+				fill = GridBagConstraints.HORIZONTAL
+				gridx = nextColumn++
+				gridy = 0
+				gridwidth = 1
+			})
+		additionalComponents.forEachIndexed { index, component ->
+			this@ComboBoxWithLabel.add(
+				component,
+				GridBagConstraints().apply {
+					weightx = 0.75
+					weighty = 0.0
+					fill = GridBagConstraints.HORIZONTAL
+					gridx = 0  // Align with the start of the combo box
+					gridy = index + 1  // Position under the combo box
+					gridwidth = 2  // Span across both label and combo box
+					insets = Insets(10, 0, 0, 0)  // Add some top margin for better spacing
+				})
+		}
+	}
+
+
+	init {
+		emptySpaceRight?.let {
+			add(
+				Box.createRigidArea(Dimension(1, 1)),
+				GridBagConstraints().apply {
+					gridx = nextColumn
+					gridy = 0
+					gridheight = 2
+					weightx = it
+				})
+		}
+		border = panelBorder
+	}
+}

--- a/avail/src/main/kotlin/avail/anvil/components/ComboWithLabel.kt
+++ b/avail/src/main/kotlin/avail/anvil/components/ComboWithLabel.kt
@@ -56,8 +56,8 @@ class ComboWithLabel<SelectionType> constructor(
 	val options: Array<SelectionType>,
 	emptySpaceRight: Double? = null,
 	emptySpaceLeft: Double? = null,
-	panelBorder: Border = BorderFactory.createEmptyBorder(10,10,10,10)
-): JPanel(GridBagLayout())
+	panelBorder: Border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+) : JPanel(GridBagLayout())
 {
 	/**
 	 * The next column for the layout.
@@ -82,14 +82,14 @@ class ComboWithLabel<SelectionType> constructor(
 	 * The [JLabel] to the left of the [JTextField].
 	 */
 	val label = JLabel(label).apply {
-			this@ComboWithLabel.add(
-				this,
-				GridBagConstraints().apply {
-					gridx = nextColumn++
-					gridy = 0
-					gridwidth = 1
-				})
-		}
+		this@ComboWithLabel.add(
+			this,
+			GridBagConstraints().apply {
+				gridx = nextColumn++
+				gridy = 0
+				gridwidth = 1
+			})
+	}
 
 	val combo = JComboBox(options).apply {
 		this@ComboWithLabel.add(
@@ -111,8 +111,9 @@ class ComboWithLabel<SelectionType> constructor(
 	 *   The [JComboBox] action called from [combo] that accepts the
 	 *   [ActionEvent] that has occurred.
 	 */
-	fun addComboActionListener (
-		action: JComboBox<SelectionType>.(ActionEvent) -> Unit)
+	fun addComboActionListener(
+		action: JComboBox<SelectionType>.(ActionEvent) -> Unit
+	)
 	{
 		combo.addActionListener {
 			combo.action(it)

--- a/avail/src/main/kotlin/avail/anvil/components/ComboWithLabel.kt
+++ b/avail/src/main/kotlin/avail/anvil/components/ComboWithLabel.kt
@@ -56,7 +56,8 @@ class ComboWithLabel<SelectionType> constructor(
 	val options: Array<SelectionType>,
 	emptySpaceRight: Double? = null,
 	emptySpaceLeft: Double? = null,
-	panelBorder: Border = BorderFactory.createEmptyBorder(10, 10, 10, 10)
+	panelBorder: Border =
+		BorderFactory.createEmptyBorder(10, 10, 10, 10)
 ) : JPanel(GridBagLayout())
 {
 	/**


### PR DESCRIPTION
Fixes #307.

Creates a new version of the create project dialog similar to what was available in Anvil.
Removes fields from the project dialog that were related to paths and projects since those are handled by IDEA.

This code still does not handle more things we need to implement, such as adding the `roots` as a source element in a module where the `avail` language can be activated and a VM can run compiling and parsing the avail sources.

I think we should consider when creating a new empty project to automatically add `gradle` or whatever build tool we think most people will use when building avail code. Currently, the created project is not useful. It does not include a Hello World or something that could get people started.

https://github.com/AvailLang/Avail/assets/456796/d01c074d-5040-4d12-b396-16db0f611ff5

