### PR TITLE
Added a one-item cache to AbstractWorkbenchTreeNode, to avoid

### DIFF
--- a/avail-server/.idea/gradle.xml
+++ b/avail-server/.idea/gradle.xml
@@ -5,7 +5,8 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_JAVA_HOME" />
+        <option name="gradleHome" value="/usr/local/Cellar/gradle/8.5/libexec" />
+        <option name="gradleJvm" value="17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/../avail" />

--- a/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
+++ b/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
@@ -2181,21 +2181,6 @@ class AvailWorkbench internal constructor(
 						}
 					}
 				})
-			addMouseListener(
-				object : MouseAdapter()
-				{
-					override fun mouseClicked(e: MouseEvent)
-					{
-						if (buildAction.isEnabled
-							&& e.clickCount == 2
-							&& e.button == MouseEvent.BUTTON1)
-						{
-							e.consume()
-							buildAction.actionPerformed(
-								ActionEvent(moduleTree, -1, "Build"))
-						}
-					}
-				})
 		}
 
 		// Create the entry points tree.
@@ -2218,11 +2203,11 @@ class AvailWorkbench internal constructor(
 				{
 					override fun mouseClicked(e: MouseEvent)
 					{
-						if (selectedEntryPoint() !== null)
+						if (insertEntryPointAction.isEnabled
+							&& e.clickCount == 2
+							&& e.button == MouseEvent.BUTTON1)
 						{
-							if (insertEntryPointAction.isEnabled
-								&& e.clickCount == 2
-								&& e.button == MouseEvent.BUTTON1)
+							if (selectedEntryPoint() !== null)
 							{
 								e.consume()
 								val actionEvent = ActionEvent(
@@ -2230,12 +2215,7 @@ class AvailWorkbench internal constructor(
 								insertEntryPointAction.actionPerformed(
 									actionEvent)
 							}
-						}
-						else if (selectedEntryPointModule() !== null)
-						{
-							if (buildEntryPointModuleAction.isEnabled
-								&& e.clickCount == 2
-								&& e.button == MouseEvent.BUTTON1)
+							else if (selectedEntryPointModule() !== null)
 							{
 								e.consume()
 								val actionEvent = ActionEvent(
@@ -3316,13 +3296,11 @@ class AvailWorkbench internal constructor(
 					is AbstractWorkbenchTreeNode ->
 					{
 						val icon = value.icon(tree.rowHeight)
-						setLeafIcon(icon)
-						setOpenIcon(icon)
-						setClosedIcon(icon)
 						var html = value.htmlText(selected)
 						html = "<html>$html</html>"
-						super.getTreeCellRendererComponent(
-							tree, html, selected, expanded, leaf, row, hasFocus)
+						// For this kind of node, use the MUCH faster caching of
+						// a JLabel for rarely changing text.
+						value.labelForText(html, icon)
 					}
 					else -> return super.getTreeCellRendererComponent(
 						tree, value, selected, expanded, leaf, row, hasFocus)

--- a/avail/src/main/kotlin/avail/anvil/nodes/AbstractWorkbenchTreeNode.kt
+++ b/avail/src/main/kotlin/avail/anvil/nodes/AbstractWorkbenchTreeNode.kt
@@ -50,7 +50,10 @@ import org.availlang.cache.LRUCache
 import java.awt.Color
 import java.awt.Image
 import javax.swing.ImageIcon
+import javax.swing.JLabel
+import javax.swing.JTree
 import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.TreeCellRenderer
 
 /**
  * A [DefaultMutableTreeNode] is a tree node used within an [AvailWorkbench].
@@ -69,6 +72,50 @@ abstract class AbstractWorkbenchTreeNode internal constructor(
 	internal val workbench: AvailWorkbench
 ) : DefaultMutableTreeNode(), Comparable<AbstractWorkbenchTreeNode>
 {
+	/**
+	 * Part of a cache optimization to get around Swing [JTree]'s RIDICULOUSLY
+	 * bad [TreeCellRenderer].  When the text attempting to be rendered agrees
+	 * with [cachedText], the [cachedLabel] should be used directly instead of
+	 * running it through the glacial HTML3.2 engine.
+	 */
+	private var cachedText: String? = null
+
+	/**
+	 * Part of a cache optimization to get around Swing [JTree]'s RIDICULOUSLY
+	 * bad [TreeCellRenderer].  When the text attempting to be rendered agrees
+	 * with [cachedText], the [cachedLabel] should be used directly instead of
+	 * running it through the glacial HTML3.2 engine.
+ 	 */
+	private var cachedLabel: JLabel? = null
+
+	/**
+	 * Given text which is likely to match previously supplied text for this
+	 * node, answer either a JLabel, using and/or caching it as appropriate.
+	 *
+	 * @param text
+	 *   The text to present, possibly starting with "&lt;html>" to indicate it
+	 *   should be interpreted as HTML3.2 styled text.
+	 * @param icon
+	 *   The optional [ImageIcon] to show to the left of the text.
+	 * @return
+	 *   A suitable JLabel to present the provided text.
+	 */
+	fun labelForText(text: String, icon: ImageIcon?): JLabel
+	{
+		val label = when (text)
+		{
+			cachedText -> cachedLabel!!
+			else ->
+			{
+				cachedText = text
+				cachedLabel = JLabel(text)
+				cachedLabel!!
+			}
+		}
+		label.icon = icon
+		return label
+	}
+
 	/** The [AvailWorkbench.availBuilder]. */
 	internal val builder: AvailBuilder get() = workbench.availBuilder
 


### PR DESCRIPTION
having to use the glacial HTML3.2 parser on every tree node every time a JTree is redrawn or resized.  It's MUCH faster.
- Removed redundant mouseClicked handler (probably a bad git merge).
- Upgraded avail-server's gradle spec to request JVM 17.