### PR TITLE
Two minor patches (undo leak in transcript and fiber join)

### DIFF
--- a/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
+++ b/avail/src/main/kotlin/avail/anvil/AvailWorkbench.kt
@@ -1155,6 +1155,7 @@ class AvailWorkbench internal constructor(
 				val beforeRemove = System.nanoTime()
 				document.remove(
 					statusSize, min(amountToRemove, length - statusSize))
+				transcript.undoManager.discardAllEdits()
 				// Always use index 0, since this only happens in the UI thread.
 				removeStringStat.record(System.nanoTime() - beforeRemove)
 			}
@@ -1165,6 +1166,7 @@ class AvailWorkbench internal constructor(
 					document.length, // The current length
 					entry.string,
 					context.documentAttributes)
+				transcript.undoManager.discardAllEdits()
 				// Always use index 0, since this only happens in the UI thread.
 				insertStringStat.record(System.nanoTime() - before)
 			}
@@ -1241,6 +1243,7 @@ class AvailWorkbench internal constructor(
 				document.remove(
 					perModuleStatusTextSize,
 					document.length - perModuleStatusTextSize)
+				transcript.undoManager.discardAllEdits()
 				// Always use index 0, since this only happens in the UI thread.
 				removeStringStat.record(System.nanoTime() - beforeRemove)
 			}

--- a/avail/src/main/kotlin/avail/interpreter/execution/Interpreter.kt
+++ b/avail/src/main/kotlin/avail/interpreter/execution/Interpreter.kt
@@ -1094,9 +1094,9 @@ class Interpreter(
 		val aFiber = fiber()
 		aFiber.lock {
 			assert(aFiber.executionState === RUNNING)
-			aFiber.executionState = state
 			aFiber.continuation = nil
 			aFiber.fiberResult = finalObject as AvailObject
+			aFiber.executionState = state
 			val bound = aFiber.getAndSetSynchronizationFlag(BOUND, false)
 			aFiber.fiberHelper.stopCountingCPU()
 			assert(bound)


### PR DESCRIPTION
- Transcript writes now clear the undo stack.  This was leaking  references, leading to out-of-memory failures.
- A one-time-ever bug showed up in the "fork and join with result" test.  The main fiber tested a forked fiber to see if it was done, then read its result, but exitFiber() wrote these two volatiles in the reverse order.  Fixed, and ran the entire concurrency test suite >900,000 times without problem.