### PR TITLE
Clawed back some performance.

### DIFF
--- a/avail/.idea/runConfigurations/All_Anvil_Tests.xml
+++ b/avail/.idea/runConfigurations/All_Anvil_Tests.xml
@@ -11,7 +11,8 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </extension>
-    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-22" />
     <option name="PACKAGE_NAME" value="avail.anvil.test" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/avail/.idea/runConfigurations/All_Avail_Tests.xml
+++ b/avail/.idea/runConfigurations/All_Avail_Tests.xml
@@ -11,7 +11,8 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </extension>
-    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-22" />
     <option name="PACKAGE_NAME" value="avail.test" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/avail/.idea/runConfigurations/Avail_Project_Manager.xml
+++ b/avail/.idea/runConfigurations/Avail_Project_Manager.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Avail Project Manager" type="JetRunConfigurationType">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17" />
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-22" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="avail.project.AvailProjectManagerRunner" />
     <module name="avail.main" />

--- a/avail/distro/src/avail/Avail.avail/Data Abstractions.avail/Pseudorandom Number Generation.avail/Mersenne Twister.avail
+++ b/avail/distro/src/avail/Avail.avail/Data Abstractions.avail/Pseudorandom Number Generation.avail/Mersenne Twister.avail
@@ -49,6 +49,8 @@ Body
 "mt" is a new field atom;
 "index" is a new field atom;
 
+u32 ::= [0..1<<32);
+
 /**
  * The Mersenne Twister pseudorandom number generator.
  *
@@ -64,8 +66,8 @@ Body
  */
 Class "Mersenne Twister" extends stream
 	with fields
-		element type : [0..1<<32)'s type,
-		mt : <[0..1<<32)…|624>,
+		element type : u32's type,
+		mt : <u32…|624>,
 		index : [1..624]
 	with reconstructors
 		(mt, index);
@@ -81,17 +83,17 @@ Method "_is empty" is
  * Compute and answer the next {@type "Mersenne Twister"} state vector.
  *
  * @method "next state after_"
- * @param "vector" "<[0..1<<32)…|624>"
+ * @param "vector" "<u32…|624>"
  *        A Mersenne Twister state vector.
- * @returns "<[0..1<<32)…|624>"
+ * @returns "<u32…|624>"
  *          A refreshed Mersenne Twister state vector.
  * @category "Data Abstractions" "Random"
  */
 Private method "next state after_" is
 [
-	vector : <[0..1<<32)…|624>
+	vector : <u32…|624>
 |
-	next : <[0..1<<32)…|624> := vector;
+	next : <u32…|624> := vector;
 	For each i from 1 to 624 do
 	[
 		y ::= (next[i] bit∧ (1<<31))
@@ -101,7 +103,7 @@ Private method "next state after_" is
 			(v bit⊕ (if y is odd then [2567483615] else [0])) bit∧ ((1<<32)-1);
 	];
 	next
-] : <[0..1<<32)…|624>;
+] : <u32…|624>;
 
 Mersenne Twister's head method is
 [
@@ -112,8 +114,8 @@ Mersenne Twister's head method is
 	y := y bit⊕ ((y × (1<<7)) bit∧ 2636928640);
 	y := y bit⊕ ((y × (1<<15)) bit∧ 4022730752);
 	y := y bit⊕ (y >> 18);
-	cast y into [t : [0..1<<32) | t]
-] : [0..1<<32);
+	y ?→ u32
+] : u32;
 
 Mersenne Twister's tail method is
 [
@@ -133,7 +135,7 @@ Mersenne Twister's tail method is
  * {@type "Mersenne Twister"} pseudorandom number generator.
  *
  * @method "untwisted Mersenne Twister from_"
- * @param "seed" "[0..1<<32)"
+ * @param "seed" "u32"
  *        A seed.
  * @returns "Mersenne Twister"
  *          An untwisted Mersenne Twister pseudorandom number generator.
@@ -141,9 +143,9 @@ Mersenne Twister's tail method is
  */
 Private method "untwisted Mersenne Twister from_" is
 [
-	seed : [0..1<<32)
+	seed : u32
 |
-	vector : <[0..1<<32)…|1..> := <seed>;
+	vector : u32+ := <seed>;
 	For each i from 1 to 623 do
 	[
 		last ::= vector's last;
@@ -151,14 +153,14 @@ Private method "untwisted Mersenne Twister from_" is
 		vector := eject vector ++ <value bit∧ ((1<<32)-1)>;
 	];
 	a Mersenne Twister with
-		element type ::= [0..1<<32),
-		mt ::= cast vector into [t : <[0..1<<32)…|624> | t],
+		element type ::= u32,
+		mt ::= vector ?→ <u32…|624>,
 		index ::= 1
 ];
 
 Method "a Mersenne Twister stream from_" is
 [
-	seed : [0..1<<32)
+	seed : u32
 |
 	rng ::= untwisted Mersenne Twister from seed;
 	rng's mt ::= next state after rng's mt, index ::= 1
@@ -171,7 +173,7 @@ Method "a Mersenne Twister stream from_" is
  * Epoch" current time} is used to initialize the generator.
  *
  * @method "a Mersenne Twister«from_»"
- * @param "optionalSeed" "[0..1<<32)?"
+ * @param "optionalSeed" "u32?"
  *        An optional seed.
  * @returns "Mersenne Twister"
  *          A Mersenne Twister pseudorandom number generator.
@@ -179,19 +181,19 @@ Method "a Mersenne Twister stream from_" is
  */
 Public method "a Mersenne Twister«from_»" is
 [
-	optionalSeed : [0..1<<32)?
+	optionalSeed : u32?
 |
 	seed ::= optionalSeed[1] else
 		[(high-precision timer value mod ((1<<32) - 1)) + 1];
-	(a reader over a Mersenne Twister stream from seed) as pRNG of [0..1<<32)
-] : pRNG of [0..1<<32);
+	(a reader over a Mersenne Twister stream from seed) as pRNG of u32
+] : pRNG of u32;
 
 Method "a Mersenne Twister stream from_" is
 [
-	seed : <[0..1<<32)…|1..>
+	seed : u32+
 |
 	rng ::= untwisted Mersenne Twister from 19650218;
-	vector : <[0..1<<32)…|624> := rng's mt;
+	vector : <u32…|624> := rng's mt;
 	i : [2..∞) := 2;
 	j : natural number := 1;
 	Repeat
@@ -229,7 +231,7 @@ Method "a Mersenne Twister stream from_" is
  * generator. The argument is a seed used to initialize the generator.
  *
  * @method "a Mersenne Twister from_"
- * @param "seed" "<[0..1<<32)…|1..>"
+ * @param "seed" "u32+"
  *        A seed.
  * @returns "Mersenne Twister"
  *          A Mersenne Twister pseudorandom number generator.
@@ -237,7 +239,7 @@ Method "a Mersenne Twister stream from_" is
  */
 Public method "a Mersenne Twister from_" is
 [
-	seed : <[0..1<<32)…|1..>
+	seed : u32+
 |
-	(a reader over a Mersenne Twister stream from seed) as pRNG of [0..1<<32)
-] : pRNG of [0..1<<32);
+	(a reader over a Mersenne Twister stream from seed) as pRNG of u32
+] : pRNG of u32;

--- a/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
@@ -2121,6 +2121,12 @@ abstract class AbstractDescriptor protected constructor (
 		value: A_BasicObject)
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	abstract fun o_AtomicAddToMapNoCheck (
+		self: AvailObject,
+		key: A_BasicObject,
+		value: A_BasicObject)
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	abstract fun o_AtomicRemoveFromMap (
 		self: AvailObject,
 		key: A_BasicObject)

--- a/avail/src/main/kotlin/avail/descriptor/representation/AvailObject.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AvailObject.kt
@@ -1080,6 +1080,12 @@ class AvailObject private constructor(
 		descriptor().o_AtomicAddToMap(this, key, value)
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	override fun atomicAddToMapNoCheck(
+		key: A_BasicObject,
+		value: A_BasicObject
+	) = descriptor().o_AtomicAddToMapNoCheck(this, key, value)
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	override fun atomicRemoveFromMap(key: A_BasicObject) =
 		descriptor().o_AtomicRemoveFromMap(this, key)
 

--- a/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
@@ -931,6 +931,12 @@ protected constructor (
 		value: A_BasicObject): Unit = unsupported
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	override fun o_AtomicAddToMapNoCheck (
+		self: AvailObject,
+		key: A_BasicObject,
+		value: A_BasicObject): Unit = unsupported
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	override fun o_AtomicRemoveFromMap (
 		self: AvailObject,
 		key: A_BasicObject): Unit = unsupported

--- a/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
@@ -3662,6 +3662,13 @@ class IndirectionDescriptor private constructor(
 	) = self .. { atomicAddToMap(key, value) }
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	override fun o_AtomicAddToMapNoCheck(
+		self: AvailObject,
+		key: A_BasicObject,
+		value: A_BasicObject
+	) = self .. { atomicAddToMapNoCheck(key, value) }
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	override fun o_AtomicRemoveFromMap(
 		self: AvailObject,
 		key: A_BasicObject

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ByteArrayTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ByteArrayTupleDescriptor.kt
@@ -57,7 +57,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteArrayTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.ByteArrayTupleDescriptor.ObjectSlots.BYTE_ARRAY_POJO
 import avail.descriptor.tuples.ByteTupleDescriptor.Companion.generateByteTupleFrom
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.concatenateAtLeastOneTree
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.createTwoPartTreeTuple
 import avail.descriptor.types.A_Type
@@ -88,9 +88,15 @@ import kotlin.math.min
  * @param mutability
  *   The [mutability][Mutability] of the new descriptor.
  */
-class ByteArrayTupleDescriptor private constructor(mutability: Mutability)
-	: NumericTupleDescriptor(
-		mutability, ObjectSlots::class.java, IntegerSlots::class.java)
+class ByteArrayTupleDescriptor
+private constructor(
+	mutability: Mutability
+) : NumericTupleDescriptor(
+	mutability,
+	ObjectSlots::class.java,
+	IntegerSlots::class.java,
+	0L,
+	255L)
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -162,7 +168,7 @@ class ByteArrayTupleDescriptor private constructor(mutability: Mutability)
 			}
 		}
 		// Transition to a tree tuple.
-		return self.concatenateWith(tuple(newElement), canDestroy)
+		return self.concatenateWith(optimizedTuple(newElement), canDestroy)
 	}
 
 	// Answer approximately how many bits per entry are taken up by this

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ByteBufferTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ByteBufferTupleDescriptor.kt
@@ -58,7 +58,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleAtPuttingCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteBufferTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.ByteBufferTupleDescriptor.ObjectSlots.BYTE_BUFFER
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.types.A_Type
 import avail.descriptor.types.A_Type.Companion.defaultType
 import avail.descriptor.types.A_Type.Companion.isSubtypeOf
@@ -86,9 +86,15 @@ import kotlin.experimental.and
  * @param mutability
  *   The [mutability][Mutability] of the new descriptor.
  */
-class ByteBufferTupleDescriptor constructor(mutability: Mutability)
-	: NumericTupleDescriptor(
-		mutability, ObjectSlots::class.java, IntegerSlots::class.java)
+class ByteBufferTupleDescriptor
+private constructor(
+	mutability: Mutability
+) : NumericTupleDescriptor(
+	mutability,
+	ObjectSlots::class.java,
+	IntegerSlots::class.java,
+	0L,
+	255L)
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -161,8 +167,7 @@ class ByteBufferTupleDescriptor constructor(mutability: Mutability)
 			}
 		}
 		// Transition to a tree tuple.
-		val singleton = tuple(newElement)
-		return self.concatenateWith(singleton, canDestroy)
+		return self.concatenateWith(optimizedTuple(newElement), canDestroy)
 	}
 
 	override fun o_ByteBuffer(self: AvailObject): ByteBuffer =

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ByteTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ByteTupleDescriptor.kt
@@ -33,9 +33,10 @@ package avail.descriptor.tuples
 
 import avail.annotations.HideFieldInDebugger
 import avail.descriptor.numbers.A_Number
-import avail.descriptor.numbers.A_Number.Companion.extractInt
+import avail.descriptor.numbers.A_Number.Companion.extractLong
 import avail.descriptor.numbers.A_Number.Companion.extractUnsignedByte
 import avail.descriptor.numbers.A_Number.Companion.isInt
+import avail.descriptor.numbers.A_Number.Companion.isLong
 import avail.descriptor.numbers.IntegerDescriptor.Companion.fromUnsignedByte
 import avail.descriptor.numbers.IntegerDescriptor.Companion.hashOfUnsignedByte
 import avail.descriptor.representation.A_BasicObject
@@ -44,6 +45,7 @@ import avail.descriptor.representation.AvailObjectRepresentation.Companion.newLi
 import avail.descriptor.representation.BitField
 import avail.descriptor.representation.IntegerSlotsEnum
 import avail.descriptor.representation.Mutability
+import avail.descriptor.representation.Mutability.MUTABLE
 import avail.descriptor.tuples.A_Tuple.Companion.compareFromToWithByteTupleStartingAt
 import avail.descriptor.tuples.A_Tuple.Companion.concatenateWith
 import avail.descriptor.tuples.A_Tuple.Companion.copyAsMutableIntTuple
@@ -56,7 +58,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.ByteTupleDescriptor.IntegerSlots.RAW_LONG_AT_
 import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.mutableObjectOfSize
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.types.A_Type
 import avail.descriptor.types.A_Type.Companion.defaultType
 import avail.descriptor.types.A_Type.Companion.isSubtypeOf
@@ -94,10 +96,16 @@ import java.nio.ByteBuffer
  *   representation of the [byte tuple][ByteTupleDescriptor]. Must be between 0
  *   and 7.
  */
-class ByteTupleDescriptor private constructor(
+class ByteTupleDescriptor
+private constructor(
 	mutability: Mutability,
-	private val unusedBytesOfLastLong: Int) : NumericTupleDescriptor(
-		mutability, null, IntegerSlots::class.java)
+	private val unusedBytesOfLastLong: Int
+) : NumericTupleDescriptor(
+	mutability,
+	null,
+	IntegerSlots::class.java,
+	0L,
+	255L)
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -144,34 +152,34 @@ class ByteTupleDescriptor private constructor(
 	{
 		val originalSize = self.tupleSize
 		val newElementStrong = newElement as AvailObject
-		if (originalSize >= maximumCopySize || !newElementStrong.isInt)
+		if (originalSize >= maximumCopySize || !newElementStrong.isLong)
 		{
 			// Transition to a tree tuple.
-			return self.concatenateWith(tuple(newElement), canDestroy)
+			return self.concatenateWith(
+				optimizedTuple(newElementStrong), canDestroy)
 		}
-		val intValue = newElementStrong.extractInt
-		if (intValue and 255.inv() != 0)
+		val longValue = newElementStrong.extractLong
+		if (longValue and 255.inv() != 0L)
 		{
-			// Transition to a tree tuple.
-			return self.concatenateWith(tuple(newElement), canDestroy)
+			// Broaden the kind of numeric tuple.
+			return super.appendLongByBroadening(self, longValue)
 		}
 		val newSize = originalSize + 1
 		if (isMutable && canDestroy && originalSize and 7 != 0)
 		{
 			// Enlarge it in place, using more of the final partial int field.
-			self.setDescriptor(descriptorFor(Mutability.MUTABLE, newSize))
-			self.setByteSlot(RAW_LONG_AT_, newSize, intValue.toShort())
+			self.setDescriptor(descriptorFor(MUTABLE, newSize))
+			self.setByteSlot(RAW_LONG_AT_, newSize, longValue.toShort())
 			self[HASH_OR_ZERO] = 0
 			return self
 		}
 		// Copy to a potentially larger ByteTupleDescriptor.
 		val result = newLike(
-			descriptorFor(Mutability.MUTABLE, newSize),
+			descriptorFor(MUTABLE, newSize),
 			self,
 			0,
 			if (originalSize and 7 == 0) 1 else 0)
-		result.setByteSlot(
-			RAW_LONG_AT_, newSize, intValue.toShort())
+		result.setByteSlot(RAW_LONG_AT_, newSize, longValue.toShort())
 		result[HASH_OR_ZERO] = 0
 		return result
 	}
@@ -266,12 +274,12 @@ class ByteTupleDescriptor private constructor(
 			{
 				// We can reuse the receiver; it has enough int slots.
 				result = self
-				result.setDescriptor(descriptorFor(Mutability.MUTABLE, newSize))
+				result.setDescriptor(descriptorFor(MUTABLE, newSize))
 			}
 			else
 			{
 				result = newLike(
-					descriptorFor(Mutability.MUTABLE, newSize), self, 0, deltaSlots)
+					descriptorFor(MUTABLE, newSize), self, 0, deltaSlots)
 			}
 			var destination = size1 + 1
 			var source = 1
@@ -558,7 +566,7 @@ class ByteTupleDescriptor private constructor(
 		@JvmStatic
 		fun mutableObjectOfSize(size: Int): AvailObject
 		{
-			val descriptor = descriptorFor(Mutability.MUTABLE, size)
+			val descriptor = descriptorFor(MUTABLE, size)
 			assert(size + descriptor.unusedBytesOfLastLong and 7 == 0)
 			return descriptor.create(size + 7 shr 3)
 		}
@@ -623,7 +631,7 @@ class ByteTupleDescriptor private constructor(
 			for (excess in intArrayOf(0, 7, 6, 5, 4, 3, 2, 1))
 			{
 				descriptors[i++] =
-					ByteTupleDescriptor(Mutability.MUTABLE, excess)
+					ByteTupleDescriptor(MUTABLE, excess)
 				descriptors[i++] =
 					ByteTupleDescriptor(Mutability.IMMUTABLE, excess)
 				descriptors[i++] =
@@ -634,7 +642,7 @@ class ByteTupleDescriptor private constructor(
 
 	override fun mutable(): ByteTupleDescriptor =
 		descriptors[(8 - unusedBytesOfLastLong and 7) * 3
-					+ Mutability.MUTABLE.ordinal]!!
+					+ MUTABLE.ordinal]!!
 
 	override fun immutable(): ByteTupleDescriptor =
 		descriptors[(8 - unusedBytesOfLastLong and 7) * 3

--- a/avail/src/main/kotlin/avail/descriptor/tuples/IntTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/IntTupleDescriptor.kt
@@ -33,8 +33,10 @@ package avail.descriptor.tuples
 
 import avail.annotations.HideFieldInDebugger
 import avail.descriptor.numbers.A_Number.Companion.extractInt
+import avail.descriptor.numbers.A_Number.Companion.extractLong
 import avail.descriptor.numbers.A_Number.Companion.greaterThan
 import avail.descriptor.numbers.A_Number.Companion.isInt
+import avail.descriptor.numbers.A_Number.Companion.isLong
 import avail.descriptor.numbers.A_Number.Companion.lessThan
 import avail.descriptor.numbers.IntegerDescriptor.Companion.computeHashOfInt
 import avail.descriptor.numbers.IntegerDescriptor.Companion.fromInt
@@ -59,7 +61,7 @@ import avail.descriptor.tuples.IntTupleDescriptor.IntegerSlots.Companion.HASH_OR
 import avail.descriptor.tuples.IntTupleDescriptor.IntegerSlots.RAW_LONG_AT_
 import avail.descriptor.tuples.LongTupleDescriptor.Companion.generateLongTupleFrom
 import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.mutableObjectOfSize
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.concatenateAtLeastOneTree
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.createTwoPartTreeTuple
 import avail.descriptor.types.A_Type
@@ -100,10 +102,16 @@ import kotlin.math.min
  *   The number of ints of the last `long` that do not participate in the
  *   representation of the [tuple][IntTupleDescriptor]. Must be 0 or 1.
  */
-class IntTupleDescriptor private constructor(
+class IntTupleDescriptor
+private constructor(
 	mutability: Mutability,
-	private val unusedIntsOfLastLong: Int) : NumericTupleDescriptor(
-		mutability, null, IntegerSlots::class.java)
+	private val unusedIntsOfLastLong: Int
+) : NumericTupleDescriptor(
+	mutability,
+	null,
+	IntegerSlots::class.java,
+	Int.MIN_VALUE.toLong(),
+	Int.MAX_VALUE.toLong())
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -150,18 +158,19 @@ class IntTupleDescriptor private constructor(
 	{
 		val originalSize = self.tupleSize
 		val newElementStrong = newElement as AvailObject
-		if (!newElementStrong.isInt)
+		if (!newElementStrong.isLong || originalSize >= maximumCopySize)
 		{
-			// Transition to a tree tuple because it's not an int.
-			val singleton = tuple(newElement)
-			return self.concatenateWith(singleton, canDestroy)
+			// Transition to a tree tuple because it's not a long or it's too
+			// big.
+			return self.concatenateWith(
+				optimizedTuple(newElementStrong), canDestroy)
 		}
-		val intValue = newElementStrong.extractInt
-		if (originalSize >= maximumCopySize)
+		val longValue = newElementStrong.extractLong
+		val intValue = longValue.toInt()
+		if (intValue.toLong() != longValue)
 		{
-			// Transition to a tree tuple because it's too big.
-			val singleton: A_Tuple = generateIntTupleFrom(1) { intValue }
-			return self.concatenateWith(singleton, canDestroy)
+			// It doesn't fit in an int, so broaden it.
+			return appendLongByBroadening(self, longValue)
 		}
 		val newSize = originalSize + 1
 		if (isMutable && canDestroy && originalSize and 1 != 0)

--- a/avail/src/main/kotlin/avail/descriptor/tuples/IntegerIntervalTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/IntegerIntervalTupleDescriptor.kt
@@ -89,9 +89,13 @@ import java.util.IdentityHashMap
  * @param mutability
  *   The mutability of the new descriptor.
  */
-class IntegerIntervalTupleDescriptor private constructor(mutability: Mutability)
-	: NumericTupleDescriptor(
-		mutability, ObjectSlots::class.java, IntegerSlots::class.java)
+class IntegerIntervalTupleDescriptor
+private constructor(
+	mutability: Mutability
+) : TupleDescriptor(
+	mutability,
+	ObjectSlots::class.java,
+	IntegerSlots::class.java)
 {
 	/**
 	 * The layout of integer slots for my instances.

--- a/avail/src/main/kotlin/avail/descriptor/tuples/LongTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/LongTupleDescriptor.kt
@@ -58,7 +58,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
 import avail.descriptor.tuples.LongTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.LongTupleDescriptor.IntegerSlots.LONG_AT_
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.concatenateAtLeastOneTree
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.createTwoPartTreeTuple
 import avail.descriptor.types.A_Type
@@ -94,7 +94,12 @@ import kotlin.math.min
 class LongTupleDescriptor
 private constructor(
 	mutability: Mutability
-) : NumericTupleDescriptor(mutability, null, IntegerSlots::class.java)
+) : NumericTupleDescriptor(
+	mutability,
+	null,
+	IntegerSlots::class.java,
+	Long.MIN_VALUE,
+	Long.MAX_VALUE)
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -141,21 +146,15 @@ private constructor(
 	{
 		val newElementStrong = newElement as AvailObject
 		val originalSize = self.tupleSize
-		if (!newElementStrong.isLong)
+		if (!newElementStrong.isLong || originalSize >= maximumCopySize)
 		{
-			// Transition to a tree tuple because it's not a long.
-			val singleton = tuple(newElement)
-			return self.concatenateWith(singleton, canDestroy)
+			// Transition to a tree tuple because it's not a long or the tuple
+			// is too big.
+			return self.concatenateWith(optimizedTuple(newElement), canDestroy)
 		}
 		val longValue = newElementStrong.extractLong
-		if (originalSize >= maximumCopySize)
-		{
-			// Transition to a tree tuple because it's too big.
-			val singleton: A_Tuple = generateLongTupleFrom(1) { longValue }
-			return self.concatenateWith(singleton, canDestroy)
-		}
 		val newSize = originalSize + 1
-		// Copy to a larger LongTupleDescriptor.
+		// always copy to a larger LongTupleDescriptor.
 		val result = newLike(mutable, self, 0, 1)
 		result[LONG_AT_, newSize] = longValue
 		result[HASH_OR_ZERO] = 0

--- a/avail/src/main/kotlin/avail/descriptor/tuples/NumericTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/NumericTupleDescriptor.kt
@@ -32,10 +32,20 @@
 package avail.descriptor.tuples
 
 import avail.descriptor.numbers.IntegerDescriptor.Companion.zero
+import avail.descriptor.representation.A_BasicObject
 import avail.descriptor.representation.AvailObject
 import avail.descriptor.representation.IntegerSlotsEnum
 import avail.descriptor.representation.Mutability
 import avail.descriptor.representation.ObjectSlotsEnum
+import avail.descriptor.tuples.A_Tuple.Companion.tupleIntAt
+import avail.descriptor.tuples.A_Tuple.Companion.tupleLongAt
+import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
+import avail.descriptor.tuples.ByteTupleDescriptor.Companion.generateByteTupleFrom
+import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
+import avail.descriptor.tuples.LongTupleDescriptor.Companion.generateLongTupleFrom
+import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.generateNybbleTupleFrom
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * `NumericTupleDescriptor` has Avail tuples of integers as its instances. The
@@ -54,17 +64,76 @@ import avail.descriptor.representation.ObjectSlotsEnum
  * @param integerSlotsEnumClass
  *   The Java [Class] which is a subclass of [IntegerSlotsEnum] and defines this
  *   object's object slots
+ * @param minimumSupportedValue
+ *   The smallest [Long] that can be stored in an object using this descriptor.
+ * @param maximumSupportedValue
+ *   The largest [Long] that can be stored in an object using this descriptor.
  */
 abstract class NumericTupleDescriptor
 protected constructor(
 	mutability: Mutability,
 	objectSlotsEnumClass: Class<out ObjectSlotsEnum>?,
-	integerSlotsEnumClass: Class<out IntegerSlotsEnum>
-) : TupleDescriptor(mutability, objectSlotsEnumClass, integerSlotsEnumClass)
+	integerSlotsEnumClass: Class<out IntegerSlotsEnum>,
+	val minimumSupportedValue: Long,
+	val maximumSupportedValue: Long
+) : TupleDescriptor(
+	mutability,
+	objectSlotsEnumClass,
+	integerSlotsEnumClass)
 {
 	abstract override fun o_TupleIntAt(self: AvailObject, index: Int): Int
 
 	abstract override fun o_TupleLongAt(self: AvailObject, index: Int): Long
 
 	override fun o_DummyElement(self: AvailObject): AvailObject = zero
+
+	/** Subclasses need to implement this. */
+	abstract override fun o_AppendCanDestroy(
+		self: AvailObject,
+		newElement: A_BasicObject,
+		canDestroy: Boolean): A_Tuple
+
+	/**
+	 * This is the fallback mechanism for appending a long to a numeric tuple.
+	 * The subclass has already failed to extend `self` while maintaining the
+	 * same representation because the value is out of range, so broaden it to
+	 * use a descriptor that allows the new value as well.
+	 *
+	 * @param self
+	 *   The numeric tuple whose descriptor is the receiver.
+	 * @param newLong
+	 *   The [Long] to be append to the tuple.
+	 * @return
+	 *   A tuple with suitable representation, containing the original elements
+	 *   of [self] and one additional element, [newLong].
+	 */
+	protected fun appendLongByBroadening(
+		self: AvailObject,
+		newLong: Long
+	): A_Tuple
+	{
+		val min = min(minimumSupportedValue, newLong)
+		val max = max(maximumSupportedValue, newLong)
+		val newSize = self.tupleSize + 1
+		return when
+		{
+			min >= 0 && max <= 0xF -> generateNybbleTupleFrom(newSize) {
+				if (it == newSize) newLong.toInt()
+				else self.tupleIntAt(it)
+			}
+			min >= 0 && max <= 0xFF -> generateByteTupleFrom(newSize) {
+				if (it == newSize) newLong.toInt()
+				else self.tupleIntAt(it)
+			}
+			min >= -0x8000_0000 && max <= 0x7FFF_FFFF ->
+				generateIntTupleFrom(newSize) {
+					if (it == newSize) newLong.toInt()
+					else self.tupleIntAt(it)
+				}
+			else -> generateLongTupleFrom(newSize) {
+				if (it == newSize) newLong
+				else self.tupleLongAt(it)
+			}
+		}
+	}
 }

--- a/avail/src/main/kotlin/avail/descriptor/tuples/NybbleTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/NybbleTupleDescriptor.kt
@@ -32,10 +32,7 @@
 package avail.descriptor.tuples
 
 import avail.annotations.HideFieldInDebugger
-import avail.descriptor.character.A_Character.Companion.codePoint
-import avail.descriptor.character.A_Character.Companion.isCharacter
 import avail.descriptor.functions.CompiledCodeDescriptor
-import avail.descriptor.numbers.A_Number.Companion.extractInt
 import avail.descriptor.numbers.A_Number.Companion.extractLong
 import avail.descriptor.numbers.A_Number.Companion.extractNybble
 import avail.descriptor.numbers.A_Number.Companion.isInt
@@ -62,17 +59,13 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAtPuttingCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleIntAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
-import avail.descriptor.tuples.ByteStringDescriptor.Companion.generateByteString
 import avail.descriptor.tuples.ByteTupleDescriptor.Companion.generateByteTupleFrom
-import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
-import avail.descriptor.tuples.LongTupleDescriptor.Companion.generateLongTupleFrom
 import avail.descriptor.tuples.NybbleTupleDescriptor.IntegerSlots
 import avail.descriptor.tuples.NybbleTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.NybbleTupleDescriptor.IntegerSlots.RAW_LONG_AT_
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.concatenateAtLeastOneTree
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.createTwoPartTreeTuple
-import avail.descriptor.tuples.TwoByteStringDescriptor.Companion.generateTwoByteString
 import avail.descriptor.types.A_Type
 import avail.descriptor.types.A_Type.Companion.defaultType
 import avail.descriptor.types.A_Type.Companion.isSubtypeOf
@@ -113,10 +106,16 @@ import kotlin.math.min
  *   The number of nybbles of the last `long` [integer
  *   slot][IntegerSlots.RAW_LONG_AT_] that are not considered part of the tuple.
  */
-class NybbleTupleDescriptor private constructor(
+class NybbleTupleDescriptor
+private constructor(
 	mutability: Mutability,
-	private val unusedNybblesOfLastLong: Int) : NumericTupleDescriptor(
-		mutability, null, IntegerSlots::class.java)
+	private val unusedNybblesOfLastLong: Int
+) : NumericTupleDescriptor(
+	mutability,
+	null,
+	IntegerSlots::class.java,
+	0L,
+	15L)
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -205,41 +204,20 @@ class NybbleTupleDescriptor private constructor(
 			// of which kind of tuple to create.  It'll probably be a good
 			// guess, and at worst we switch to a more general form when the
 			// second element shows up.
-			when
-			{
-				strongNewElement.isCharacter ->
-					return when (val codePoint = strongNewElement.codePoint)
-					{
-						in 0 .. 0xFF -> generateByteString(1) { codePoint }
-						in 0 .. 0xFFFF ->
-							generateTwoByteString(1) { codePoint.toUShort() }
-						else -> tuple(strongNewElement)
-					}
-				strongNewElement.isLong ->
-					return when (val longValue = strongNewElement.extractLong)
-					{
-						in 0..0xF -> generateNybbleTupleFrom(1) {
-							longValue.toInt()
-						}
-						in 0 .. 0xFF -> generateByteTupleFrom(1) {
-							longValue.toInt()
-						}
-						in -0x8000_0000 .. 0x7FFF_FFFF ->
-							generateIntTupleFrom(1) { longValue.toInt() }
-						else -> generateLongTupleFrom(1) { longValue }
-					}
-			}
+			return optimizedTuple(strongNewElement)
 		}
-		if (originalSize < maximumCopySize && strongNewElement.isInt)
+		if (originalSize < maximumCopySize && strongNewElement.isLong)
 		{
-			val intValue = strongNewElement.extractInt
-			if (intValue and 15.inv() != 0)
-			{
-				// Transition to a tree tuple.
-				val singleton = tuple(strongNewElement)
-				return self.concatenateWith(singleton, canDestroy)
-			}
+			val longValue = strongNewElement.extractLong
 			val newSize = originalSize + 1
+			if (longValue and 15.inv() != 0L)
+			{
+				// The result can't stay a nybble tuple, but it's still small
+				// enough that we can upgrade it.
+				return appendLongByBroadening(
+					self, strongNewElement.extractLong)
+			}
+			// Extend the nybble tuple.
 			val result: AvailObject
 			if (isMutable && canDestroy && originalSize and 15 != 0)
 			{
@@ -255,13 +233,13 @@ class NybbleTupleDescriptor private constructor(
 					0,
 					if (originalSize and 15 == 0) 1 else 0)
 			}
-			setNybble(result, newSize, intValue.toByte())
+			setNybble(result, newSize, longValue.toByte())
 			result[HASH_OR_ZERO] = 0
 			return result
 		}
 		// Transition to a tree tuple.
-		val singleton = tuple(strongNewElement)
-		return self.concatenateWith(singleton, canDestroy)
+		return self.concatenateWith(
+			optimizedTuple(strongNewElement), canDestroy)
 	}
 
 	// Answer approximately how many bits per entry are taken up by this

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ObjectTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ObjectTupleDescriptor.kt
@@ -32,6 +32,9 @@
 package avail.descriptor.tuples
 
 import avail.annotations.HideFieldInDebugger
+import avail.descriptor.character.A_Character.Companion.codePoint
+import avail.descriptor.character.A_Character.Companion.isCharacter
+import avail.descriptor.numbers.A_Number.Companion.extractLong
 import avail.descriptor.numbers.A_Number.Companion.isInt
 import avail.descriptor.numbers.A_Number.Companion.isLong
 import avail.descriptor.representation.A_BasicObject
@@ -48,8 +51,15 @@ import avail.descriptor.tuples.A_Tuple.Companion.isBetterRepresentationThan
 import avail.descriptor.tuples.A_Tuple.Companion.treeTupleLevel
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
+import avail.descriptor.tuples.ByteStringDescriptor.Companion.generateByteString
+import avail.descriptor.tuples.ByteTupleDescriptor.Companion.generateByteTupleFrom
+import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
+import avail.descriptor.tuples.LongTupleDescriptor.Companion.generateLongTupleFrom
+import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.generateNybbleTupleFrom
 import avail.descriptor.tuples.ObjectTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.ObjectTupleDescriptor.ObjectSlots.TUPLE_AT_
+import avail.descriptor.tuples.TwentyOneBitStringDescriptor.Companion.generateTwentyOneBitString
+import avail.descriptor.tuples.TwoByteStringDescriptor.Companion.generateTwoByteString
 import avail.optimizer.jvm.CheckedMethod
 import avail.optimizer.jvm.CheckedMethod.Companion.staticMethod
 import avail.optimizer.jvm.ReferencedInGeneratedCode
@@ -632,6 +642,39 @@ class ObjectTupleDescriptor private constructor(mutability: Mutability)
 			"tuple",
 			A_Tuple::class.java,
 			A_BasicObject::class.java)
+
+		/**
+		 * Given a single element, create a tuple using a fully optimized
+		 * descriptor, based on the element's value.
+		 */
+		fun optimizedTuple(element1: AvailObject): A_Tuple
+		{
+			return when
+			{
+				element1.isCharacter ->
+					when (val codePoint = element1.codePoint)
+					{
+						in 0 .. 0xFF -> generateByteString(1) { codePoint }
+						in 0 .. 0xFFFF ->
+							generateTwoByteString(1) { codePoint.toUShort() }
+						else -> generateTwentyOneBitString(1) { codePoint }
+					}
+				element1.isLong ->
+					when (val longValue = element1.extractLong)
+					{
+						in 0..0xF -> generateNybbleTupleFrom(1) {
+							longValue.toInt()
+						}
+						in 0 .. 0xFF -> generateByteTupleFrom(1) {
+							longValue.toInt()
+						}
+						in -0x8000_0000 .. 0x7FFF_FFFF ->
+							generateIntTupleFrom(1) { longValue.toInt() }
+						else -> generateLongTupleFrom(1) { longValue }
+					}
+				else -> tuple(element1)
+			}
+		}
 
 		/**
 		 * Create a tuple with the specified two elements. The elements are not

--- a/avail/src/main/kotlin/avail/descriptor/tuples/SmallIntegerIntervalTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/SmallIntegerIntervalTupleDescriptor.kt
@@ -54,7 +54,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteTupleDescriptor.Companion.generateByteTupleFrom
 import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.generateObjectTupleFrom
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.SmallIntegerIntervalTupleDescriptor.IntegerSlots.Companion.END
 import avail.descriptor.tuples.SmallIntegerIntervalTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.SmallIntegerIntervalTupleDescriptor.IntegerSlots.Companion.SIZE
@@ -80,9 +80,14 @@ import java.util.IdentityHashMap
  *   The mutability of the descriptor.
  */
 class SmallIntegerIntervalTupleDescriptor
-constructor(
+private constructor(
 	mutability: Mutability
-) : NumericTupleDescriptor(mutability, null, IntegerSlots::class.java)
+) : NumericTupleDescriptor(
+	mutability,
+	null,
+	IntegerSlots::class.java,
+	Int.MIN_VALUE.toLong(),
+	Int.MAX_VALUE.toLong())
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -168,8 +173,8 @@ constructor(
 		if (newElementStrong.isInt)
 		{
 			val newElementValue = newElementStrong.extractInt
-			if (newElementValue.toLong() ==
-				endValue + deltaValue && originalSize < Int.MAX_VALUE)
+			if (newElementValue.toLong() == endValue + deltaValue
+				&& originalSize < Int.MAX_VALUE)
 			{
 				// Extend the interval.
 				if (canDestroy && isMutable)
@@ -195,8 +200,7 @@ constructor(
 			// Too big; fall through and make a tree-tuple.
 		}
 		// Fall back to concatenating a singleton.
-		val singleton = tuple(newElement)
-		return self.concatenateWith(singleton, canDestroy)
+		return self.concatenateWith(optimizedTuple(newElement), canDestroy)
 	}
 
 	// Consider a billion element tuple. Since a small interval tuple

--- a/avail/src/main/kotlin/avail/descriptor/tuples/StringDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/StringDescriptor.kt
@@ -41,13 +41,11 @@ import avail.descriptor.representation.IntegerSlotsEnum
 import avail.descriptor.representation.Mutability
 import avail.descriptor.representation.ObjectSlotsEnum
 import avail.descriptor.tuples.A_String.Companion.asNativeString
-import avail.descriptor.tuples.A_Tuple.Companion.tupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAtPuttingCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleCodePointAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteStringDescriptor.Companion.createUninitializedByteString
 import avail.descriptor.tuples.ByteStringDescriptor.Companion.mutableObjectFromNativeByteString
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.generateObjectTupleFrom
 import avail.descriptor.tuples.TwentyOneBitStringDescriptor.Companion.generateTwentyOneBitString
 import avail.descriptor.tuples.TwoByteStringDescriptor.Companion.generateTwoByteString
 import avail.descriptor.tuples.TwoByteStringDescriptor.Companion.mutableObjectFromNativeTwoByteString
@@ -270,8 +268,8 @@ abstract class StringDescriptor protected constructor(
 					else ->
 					{
 						assert(codePoint <= maxCodePointInt)
-						string = generateObjectTupleFrom(size) {
-							string.tupleAt(it)
+						string = generateTwentyOneBitString(size) {
+							string.tupleCodePointAt(it)
 						}
 						representationLimit = maxCodePointInt
 					}

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TupleDescriptor.kt
@@ -33,6 +33,7 @@ package avail.descriptor.tuples
 
 import avail.annotations.HideFieldInDebugger
 import avail.annotations.ThreadSafe
+import avail.descriptor.atoms.AtomDescriptor.Companion.falseObject
 import avail.descriptor.character.A_Character.Companion.codePoint
 import avail.descriptor.character.A_Character.Companion.isCharacter
 import avail.descriptor.numbers.A_Number.Companion.extractInt
@@ -47,7 +48,6 @@ import avail.descriptor.representation.Descriptor
 import avail.descriptor.representation.IndirectionDescriptor
 import avail.descriptor.representation.IntegerSlotsEnum
 import avail.descriptor.representation.Mutability
-import avail.descriptor.representation.NilDescriptor.Companion.nil
 import avail.descriptor.representation.ObjectSlotsEnum
 import avail.descriptor.sets.A_Set
 import avail.descriptor.sets.SetDescriptor.Companion.generateSetFrom
@@ -674,7 +674,7 @@ protected constructor(
 		return SubrangeTupleDescriptor.createSubrange(self, start, size)
 	}
 
-	override fun o_DummyElement(self: AvailObject) = nil
+	override fun o_DummyElement(self: AvailObject) = falseObject as AvailObject
 
 	override fun o_ExtractNybbleFromTupleAt(
 		self: AvailObject, index: Int): Byte

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TwentyOneBitStringDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TwentyOneBitStringDescriptor.kt
@@ -61,6 +61,9 @@ import avail.descriptor.tuples.TreeTupleDescriptor.Companion.createTwoPartTreeTu
 import avail.descriptor.tuples.TwentyOneBitStringDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.TwentyOneBitStringDescriptor.IntegerSlots.RAW_LONGS_
 import avail.descriptor.tuples.TwoByteStringDescriptor.Companion.generateTwoByteString
+import avail.optimizer.jvm.CheckedMethod
+import avail.optimizer.jvm.CheckedMethod.Companion.staticMethod
+import avail.optimizer.jvm.ReferencedInGeneratedCode
 import kotlin.math.max
 import kotlin.math.min
 
@@ -538,8 +541,18 @@ class TwentyOneBitStringDescriptor private constructor(
 		 * @return
 		 *   The new tuple, initialized to null characters (code point 0).
 		 */
-		private fun mutableTwentyOneBitStringOfSize(size: Int): AvailObject =
+		@ReferencedInGeneratedCode
+		@JvmStatic
+		fun mutableTwentyOneBitStringOfSize(size: Int): AvailObject =
 			descriptorFor(MUTABLE, size).create((size + 2).div3)
+
+		/** The [CheckedMethod] for [mutableTwentyOneBitStringOfSize]. */
+		val createUninitializedTwentyOneBitStringMethod =
+			staticMethod(
+				TwentyOneBitStringDescriptor::class.java,
+				::mutableTwentyOneBitStringOfSize.name,
+				AvailObject::class.java,
+				Int::class.javaPrimitiveType!!)
 
 		/**
 		 * Answer the descriptor that has the specified mutability flag and is
@@ -636,7 +649,8 @@ class TwentyOneBitStringDescriptor private constructor(
 		}
 
 		/**
-		 * Answer a mutable copy of object that also only holds 21-bit characters.
+		 * Answer a mutable copy of object that also only holds 21-bit
+		 * characters.
 		 *
 		 * @param self
 		 *   A string to copy, in any representation.

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TwoByteStringDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TwoByteStringDescriptor.kt
@@ -52,7 +52,6 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleAtPuttingCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleCodePointAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteStringDescriptor.Companion.generateByteString
-import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.mutableObjectOfSize
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.concatenateAtLeastOneTree
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.createTwoPartTreeTuple
@@ -562,7 +561,7 @@ class TwoByteStringDescriptor private constructor(
 		fun mutableTwoByteStringOfSize(size: Int): AvailObject =
 			descriptorFor(Mutability.MUTABLE, size).create(size + 3 shr 2)
 
-		/** The [CheckedMethod] for [mutableObjectOfSize]. */
+		/** The [CheckedMethod] for [mutableTwoByteStringOfSize]. */
 		val createUninitializedTwoByteStringMethod =
 			staticMethod(
 				TwoByteStringDescriptor::class.java,

--- a/avail/src/main/kotlin/avail/descriptor/variables/A_Variable.kt
+++ b/avail/src/main/kotlin/avail/descriptor/variables/A_Variable.kt
@@ -332,6 +332,29 @@ interface A_Variable : A_ChunkDependable
 	fun atomicAddToMap(key: A_BasicObject, value: A_BasicObject)
 
 	/**
+	 * Extract the map from this variable, add the key → value binding to it,
+	 * and write it back into the variable.  Don't check the map's type before
+	 * writing it – assume it was already guaranteed statically.  Require the
+	 * key and values be compatible with the variable's map type.  Require that
+	 * the variable contains a map (or is unassigned), and that the map type's
+	 * maximum size is ∞, to ensure it will accept the new map.
+	 *
+	 * This is an atomic operation, so the update is serialized with respect
+	 * to other operations on this variable.
+	 *
+	 * @param key
+	 *   The key to add to the map.
+	 * @param value
+	 *   The value to add to the map.
+	 * @throws VariableGetException
+	 *   If the variable does not contain a map (i.e., it's unassigned).
+	 * @throws VariableSetException
+	 *    If the updated map cannot be written back.
+	 */
+	@Throws(VariableGetException::class, VariableSetException::class)
+	fun atomicAddToMapNoCheck(key: A_BasicObject, value: A_BasicObject)
+
+	/**
 	 * Extract the map from this variable, remove the key if present, and write
 	 * it back into the variable.
 	 *

--- a/avail/src/main/kotlin/avail/descriptor/variables/VariableDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/variables/VariableDescriptor.kt
@@ -472,6 +472,21 @@ open class VariableDescriptor protected constructor(
 	}
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	override fun o_AtomicAddToMapNoCheck(
+		self: AvailObject,
+		key: A_BasicObject,
+		value: A_BasicObject)
+	{
+		handleVariableWriteTracing(self)
+		val oldMap: A_Map = self[VALUE]
+		if (oldMap.isNil)
+			throw VariableGetException(E_CANNOT_READ_UNASSIGNED_VARIABLE)
+		val newMap = oldMap.mapAtPuttingCanDestroy(key, value, true)
+		// Don't check the type of the new map.
+		self[VALUE] = newMap.makeShared()
+	}
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	override fun o_AtomicRemoveFromMap(
 		self: AvailObject,
 		key: A_BasicObject)

--- a/avail/src/main/kotlin/avail/descriptor/variables/VariableSharedDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/variables/VariableSharedDescriptor.kt
@@ -426,6 +426,28 @@ open class VariableSharedDescriptor protected constructor(
 	}
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	override fun o_AtomicAddToMapNoCheck(
+		self: AvailObject,
+		key: A_BasicObject,
+		value: A_BasicObject)
+	{
+		// Simply read, add, and compare-and-set until it succeeds.  We require
+		// that the variable holds maps of arbitrarily large size (to allow it
+		// to grow without violating the content type during the add), the key
+		// and value types are acceptable for the contained map type, and that
+		// the variable can only store maps (i.e., not `any`).  It may still
+		// fail if the variable is unassigned.
+		do
+		{
+			val oldValue = self.volatileSlot(VALUE)
+			if (oldValue.isNil)
+				throw VariableGetException(E_CANNOT_READ_UNASSIGNED_VARIABLE)
+			val newMap = oldValue.mapAtPuttingCanDestroy(key, value, false)
+		}
+		while (!o_CompareAndSwapValuesNoCheck(self, oldValue, newMap))
+	}
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	override fun o_AtomicRemoveFromMap(
 		self: AvailObject,
 		key: A_BasicObject)

--- a/avail/src/main/kotlin/avail/descriptor/variables/VariableSharedGlobalDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/variables/VariableSharedGlobalDescriptor.kt
@@ -281,6 +281,19 @@ class VariableSharedGlobalDescriptor private constructor(
 	}
 
 	@Throws(VariableGetException::class, VariableSetException::class)
+	override fun o_AtomicAddToMapNoCheck(
+		self: AvailObject,
+		key: A_BasicObject,
+		value: A_BasicObject)
+	{
+		if (writeOnce)
+		{
+			throw VariableSetException(E_CANNOT_OVERWRITE_WRITE_ONCE_VARIABLE)
+		}
+		super.o_AtomicAddToMapNoCheck(self, key, value)
+	}
+
+	@Throws(VariableGetException::class, VariableSetException::class)
 	override fun o_AtomicRemoveFromMap(self: AvailObject, key: A_BasicObject)
 	{
 		if (writeOnce)

--- a/avail/src/main/kotlin/avail/interpreter/Primitive.kt
+++ b/avail/src/main/kotlin/avail/interpreter/Primitive.kt
@@ -71,6 +71,8 @@ import avail.interpreter.Primitive.Flag.SpecialForm
 import avail.interpreter.Primitive.Flag.Unknown
 import avail.interpreter.Primitive.PrimitiveHolder
 import avail.interpreter.Primitive.PrimitiveHolder.Companion.holdersByClassName
+import avail.interpreter.Primitive.Result.FAILURE
+import avail.interpreter.Primitive.Result.SUCCESS
 import avail.interpreter.execution.Interpreter
 import avail.interpreter.execution.Interpreter.Companion.afterAttemptPrimitiveMethod
 import avail.interpreter.execution.Interpreter.Companion.argsBufferField
@@ -81,7 +83,6 @@ import avail.interpreter.levelOne.L1InstructionWriter
 import avail.interpreter.levelOne.L1Operation
 import avail.interpreter.levelTwo.L2Chunk
 import avail.interpreter.levelTwo.L2Instruction
-import avail.interpreter.levelTwo.L2JVMChunk.Companion.unoptimizedChunk
 import avail.interpreter.levelTwo.operand.L2ArbitraryConstantOperand
 import avail.interpreter.levelTwo.operand.L2ConstantOperand
 import avail.interpreter.levelTwo.operand.L2ReadBoxedOperand
@@ -995,18 +996,14 @@ abstract class Primitive constructor (val argCount: Int, vararg flags: Flag)
 	/**
 	 * Attempt to generate a simplified, faster invocation of the given constant
 	 * function, with the given argument restrictions.  The arguments will be on
-	 * the stack, the last-pushed one at stackp.  If this code generation
-	 * attempt is successful, code will be generated to invoke the given
-	 * function, and if it completes without reification, to check the return
-	 * result if it's not already guaranteed correct.  The unchecked value will
-	 * be written into the semantic value for the stack slot for when the pc is
-	 * the next instruction minus one, to distinguish it from the checked value
-	 * (same slot, but for when the pc is the next instruction).
+	 * the stack, the last-pushed one at stackp.  Return null to fall back
+	 * statically to a regular invocation if the primitive can't guarantee to
+	 * meet the strengthened type at this call site.  Likewise fall back if the
+	 * primitive might fail or suspend.
 	 *
-	 * If reification happens, the continuation that will be produced at runtime
-	 * should be of the simple L1 form, using the [unoptimizedChunk].  It should
-	 * have the expected type pushed on the stack in preparation for checking
-	 * against the return type, once the continuation is "returned into".
+	 * If this code generation attempt is successful, return a
+	 * [TypeRestriction], indicating the guaranteed result type for the call.
+	 * An invocation will be emitted to the [L2SimpleTranslator] in this case.
 	 */
 	open fun attemptToGenerateSimpleInvocation(
 		simpleTranslator: L2SimpleTranslator,
@@ -1026,25 +1023,90 @@ abstract class Primitive constructor (val argCount: Int, vararg flags: Flag)
 			|| hasFlag(CanSwitchContinuations)
 			|| hasFlag(CanSuspend)
 			|| hasFlag(Invokes)
-			|| hasFlag(Unknown)
-			|| fallibilityForArgumentTypes(argTypes) != CallSiteCannotFail)
+			|| hasFlag(Unknown))
 		{
-			// The primitive might fail.
+			// The primitive might suspend or invoke.  Fall back to a general
+			// invocation.
 			return null
 		}
-		// The primitive cannot fail here.
 		val guaranteedType = returnTypeGuaranteedByVM(rawFunction, argTypes)
 		if (!guaranteedType.isSubtypeOf(expectedType))
 		{
 			// The result isn't strong enough to satisfy the expectedType.
 			return null
 		}
-		simpleTranslator.add(
-			L2Simple_RunInfalliblePrimitiveNoCheck(
-				simpleTranslator.stackp,
-				functionIfKnown,
-				rawFunction))
-		return boxedRestrictionForType(guaranteedType)
+		when (fallibilityForArgumentTypes(argTypes))
+		{
+			CallSiteCanFail ->
+			{
+				// This primitive invocation might fail.  However, this might be
+				// a very rare situation.  If the primitive has no side-effect
+				// on failure, it may be beneficial to just try it, falling back
+				// to a general invocation dynamically – which re-attempts the
+				// primitive.
+				val nilpotentAttempt = simplePrimitiveNilpotentInvocation(
+					simpleTranslator,
+					functionIfKnown,
+					rawFunction,
+					argRestrictions,
+					expectedType)
+				if (nilpotentAttempt !== null)
+				{
+					return simpleTranslator.generateGeneralInvocation(
+						nilpotentAttempt,
+						functionIfKnown,
+						expectedType)
+				}
+				// It can fail, but there's no nilpotent function to invoke.
+				// Fall back to a general invocation.
+				return null
+			}
+			CallSiteCannotFail ->
+			{
+				// The primitive cannot fail.
+				simpleTranslator.add(
+					L2Simple_RunInfalliblePrimitiveNoCheck(
+						simpleTranslator.stackp,
+						functionIfKnown,
+						rawFunction))
+				return boxedRestrictionForType(guaranteedType)
+			}
+			else ->
+			{
+				// Fall back to a general invocation.
+				return null
+			}
+		}
+	}
+
+	/**
+	 * This call site may fail.  The result type must have been verified strong
+	 * enough for this call site.  Answer a function that will attempt to run a
+	 * specialized version of the fallible primitive, answering the [Result].
+	 * This will be plugged into the L2Simple code in such a way that if the
+	 * primitive fails, a full invocation will take place instead.
+	 *
+	 * Answer null if the fallible primitive invocation should not happen this
+	 * way, which will cause a regular function invocation to occur instead.
+	 */
+	open fun simplePrimitiveNilpotentInvocation(
+		simpleTranslator: L2SimpleTranslator,
+		functionIfKnown: A_Function?,
+		rawFunction: A_RawFunction,
+		argRestrictions: List<TypeRestriction>,
+		expectedType: A_Type
+	): ((Interpreter)->Result)?
+	{
+		functionIfKnown ?: return null
+		return { interpreter ->
+			// At this point, the arguments have been pushed in the interpreter.
+			val result = interpreter.afterAttemptPrimitive(
+				this@Primitive,
+				interpreter.beforeAttemptPrimitive(this@Primitive),
+				attempt(interpreter))
+			assert(result == SUCCESS || result == FAILURE)
+			result
+		}
 	}
 
 	/**

--- a/avail/src/main/kotlin/avail/interpreter/execution/Interpreter.kt
+++ b/avail/src/main/kotlin/avail/interpreter/execution/Interpreter.kt
@@ -133,6 +133,7 @@ import avail.interpreter.Primitive.Result.READY_TO_INVOKE
 import avail.interpreter.Primitive.Result.SUCCESS
 import avail.interpreter.levelTwo.L1InstructionStepper
 import avail.interpreter.levelTwo.L2Chunk
+import avail.interpreter.levelTwo.L2Instruction
 import avail.interpreter.levelTwo.L2JVMChunk.ChunkEntryPoint
 import avail.interpreter.levelTwo.L2JVMChunk.Companion.unoptimizedChunk
 import avail.interpreter.levelTwo.operation.L2_INVOKE
@@ -1198,7 +1199,8 @@ class Interpreter(
 	@ReferencedInGeneratedCode
 	fun attemptInlinePrimitive(
 		primitiveFunction: A_Function,
-		primitive: Primitive): StackReifier?
+		primitive: Primitive
+	): StackReifier?
 	{
 		// It can succeed or fail, but it can't mess with the fiber's stack.
 		if (debugL2)

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/L1InstructionStepper.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/L1InstructionStepper.kt
@@ -80,6 +80,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleIntAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.generateObjectTupleFrom
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.generateReversedFrom
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tupleFromList
 import avail.descriptor.tuples.TupleDescriptor.Companion.emptyTuple
@@ -530,7 +531,7 @@ class L1InstructionStepper constructor(val interpreter: Interpreter)
 					when (val size = instructionDecoder.getOperand())
 					{
 						0 -> push(emptyTuple)
-						1 -> push(tuple(pop()))
+						1 -> push(optimizedTuple(pop()))
 						else -> push(generateReversedFrom(size) { pop() })
 					}
 				}

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/operand/L2WriteOperand.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/operand/L2WriteOperand.kt
@@ -36,13 +36,9 @@ import avail.interpreter.levelTwo.operation.L2_MOVE_CONSTANT
 import avail.interpreter.levelTwo.register.L2IntRegister
 import avail.interpreter.levelTwo.register.L2Register
 import avail.interpreter.levelTwo.register.RegisterKind
-import avail.optimizer.L2ControlFlowGraph
-import avail.optimizer.L2GeneratorInterface
 import avail.optimizer.L2Synonym
 import avail.optimizer.L2ValueManifest
-import avail.optimizer.values.L2SemanticDummy
 import avail.optimizer.values.L2SemanticValue
-import avail.utility.cast
 
 /**
  * `L2WriteOperand` abstracts the capabilities of actual register write
@@ -266,28 +262,6 @@ constructor(
 	override fun appendTo(builder: StringBuilder)
 	{
 		builder.append("→").append(registerString())
-	}
-
-	/**
-	 * The [L2SemanticValue]s associated with this write are no longer relevant
-	 * to the [L2ControlFlowGraph].  Replace them with a single dummy value
-	 * associated with the [L2Register] being written.
-	 *
-	 * @param generator
-	 *   The [L2GeneratorInterface] that's used to generate unique ids.
-	 * @param registerToValueMap
-	 *   A map from each encountered [L2Register] to an [L2SemanticDummy] that
-	 *   is generated for it as needed.
-	 */
-	@Deprecated("TODO Remove")
-	fun clearSemanticValues(
-		generator: L2GeneratorInterface,
-		registerToValueMap: MutableMap<L2Register<*>, L2SemanticValue<*>>)
-	{
-		semanticValues = setOf(
-			registerToValueMap.computeIfAbsent(register) {
-				kind.createSemanticDummy(generator)
-			}.cast())
 	}
 
 	override fun postOptimizationCleanup()

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_CREATE_TUPLE.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_CREATE_TUPLE.kt
@@ -32,6 +32,7 @@
 package avail.interpreter.levelTwo.operation
 
 import avail.descriptor.character.A_Character.Companion.codePoint
+import avail.descriptor.numbers.IntegerDescriptor.Companion.one
 import avail.descriptor.representation.A_BasicObject
 import avail.descriptor.representation.AvailObject
 import avail.descriptor.tuples.ByteStringDescriptor.Companion.createUninitializedByteStringMethod
@@ -46,9 +47,14 @@ import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple3Method
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple4Method
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple5Method
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tupleFromArrayMethod
+import avail.descriptor.tuples.StringDescriptor.Companion.generateStringFromCodePoints
 import avail.descriptor.tuples.TupleDescriptor
 import avail.descriptor.tuples.TupleDescriptor.Companion.tupleAtPuttingMethod
+import avail.descriptor.tuples.TwentyOneBitStringDescriptor.Companion.createUninitializedTwentyOneBitStringMethod
 import avail.descriptor.tuples.TwoByteStringDescriptor.Companion.createUninitializedTwoByteStringMethod
+import avail.descriptor.types.A_Type
+import avail.descriptor.types.A_Type.Companion.instance
+import avail.descriptor.types.A_Type.Companion.instanceCount
 import avail.descriptor.types.A_Type.Companion.instances
 import avail.descriptor.types.A_Type.Companion.isSubtypeOf
 import avail.descriptor.types.A_Type.Companion.typeUnion
@@ -121,27 +127,66 @@ class L2_CREATE_TUPLE(
 		{
 			unionType.isSubtypeOf(Types.CHARACTER.o) ->
 			{
+				val maxCodepoint = elements.elements
+					.map(L2ReadBoxedOperand::type)
+					.filter(A_Type::isEnumeration)
+					.maxOfOrNull { it.instances.maxOf { c -> c.codePoint} }
+				val constantEntries = elements.elements.map { read ->
+					read.type().run {
+						if (instanceCount.equals(one)) instance
+						else null
+					}
+				}
+				if (constantEntries.any { it !== null })
+				{
+					// Some of the elements are constant.  Pre-build a constant
+					// string with those values filled in, and dummy characters
+					// for the rest, then generate code to push that string and
+					// perform necessary updates on it (the first update will
+					// clone it as mutable).
+					val template = generateStringFromCodePoints(size) {
+						constantEntries[it]?.codePoint ?: 0
+					}.makeShared()
+					translator.literal(method, template)
+					// :: template-string
+					elements.elements.forEachIndexed { zeroIndex, read ->
+						if (constantEntries[zeroIndex] === null)
+						{
+							// Replace the dummy character, cloning the template
+							// and even changing its representation if needed.
+							translator.intConstant(method, zeroIndex + 1)
+							translator.load(method, read.register())
+							tupleAtPuttingMethod.generateCall(method)
+						}
+					}
+					// :: string
+					translator.store(method, tuple.register())
+					return
+				}
+				// There weren't any literal character elements.
 				translator.intConstant(method, size)
 				// :: size
-				if (elements.elements.any { read ->
-						read.type().run {
-							isEnumeration &&
-								instances.any { c -> c.codePoint > 255 }
-						}
-					})
+				if (maxCodepoint === null || maxCodepoint <= 0xFF)
 				{
-					// At least one element type is an enumeration that contains
-					// a non-Latin-1 character.  Not a perfect indicator by a
-					// long shot, but probably a pretty good predictor that this
-					// should start out as a two-byte-string.
+					// There are no enumeration character types present, or
+					// they're all single-bytes. Guess that we're creating a
+					// byte string, although it may have to be upgraded.
+					createUninitializedByteStringMethod.generateCall(method)
+					// :: uninitiaalized-byte-string
+				}
+				else if (maxCodepoint <= 0xFFFF)
+				{
+					// A two-byte character may be present.
 					createUninitializedTwoByteStringMethod.generateCall(method)
 					// :: uninitialized-two-byte-string
 				}
 				else
 				{
-					// Otherwise, just guess that it'll stay a byte-string.
-					createUninitializedByteStringMethod.generateCall(method)
-					// :: uninitialized-byte-string
+					// One of the enumerations for an element indicated a
+					// possible value beyond the 16-bit range.
+					createUninitializedTwentyOneBitStringMethod.generateCall(
+						method)
+					// :: uninitialized-21-bit-string
 				}
 			}
 			unionType.isSubtypeOf(i64) ->

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_JUMP_IF_OBJECTS_EQUAL.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_JUMP_IF_OBJECTS_EQUAL.kt
@@ -113,13 +113,11 @@ class L2_JUMP_IF_OBJECTS_EQUAL(
 		}
 		restriction1.constantOrNull?.let { c1 ->
 			restriction2.constantOrNull?.let { c2 ->
-				if (c1.equals(c2))
-				{
-					// The restrictions say the values are the same constant, so
-					// it's always true.  Jump unconditionally to the true case.
-					regenerator.jumpTo(ifEqual.targetBlock())
-					return
-				}
+				// The restrictions say the values are both constants, so jump
+				// unconditionally based on whether those constants are equal.
+				if (c1.equals(c2)) regenerator.jumpTo(ifEqual.targetBlock())
+				else regenerator.jumpTo(ifNotEqual.targetBlock())
+				return
 			}
 		}
 		if (!first.restriction().containedByType(i32)
@@ -159,9 +157,8 @@ class L2_JUMP_IF_OBJECTS_EQUAL(
 		if (first.restriction().intersectsType(i32)
 			&& second.restriction().intersectsType(i32))
 		{
-			conditions.add(
-				unboxedIntCondition(
-					listOf(first.register(), second.register())))
+			conditions.add(unboxedIntCondition(listOf(first.register())))
+			conditions.add(unboxedIntCondition(listOf(second.register())))
 		}
 		return conditions
 	}

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_MULTIWAY_JUMP.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_MULTIWAY_JUMP.kt
@@ -96,9 +96,18 @@ import kotlin.math.min
  * second entry, jump to the second target, and so on.  If the integer is
  * greater than the last entry, jump to the N+1st target.
  *
+ * @property value
+ *   The [L2ReadIntOperand] providing the [Int] being dispatched.
+ * @property splitter
+ *   The [L2ArbitraryConstantOperand] holding the [AbstractMultiWaySplitter]
+ *   that determines how to jump.
+ * @param branchEdges
+ *   The [L2PcVectorOperand] contaaining the branch targets that the [splitter]
+ *   is supposed to dispatch to.
  * @author Mark van Gulik &lt;mark@availlang.org&gt;
  */
-class L2_MULTIWAY_JUMP(
+class L2_MULTIWAY_JUMP
+constructor(
 	var value: L2ReadIntOperand,
 	var splitter: L2ArbitraryConstantOperand<AbstractMultiWaySplitter>,
 	@On(SUCCESS) var branchEdges: L2PcVectorOperand
@@ -278,7 +287,8 @@ class L2_MULTIWAY_JUMP(
  * without polluting code with logic for special uses (dispatching by [TypeTag]
  * or [ObjectLayoutVariant]).
  */
-abstract class AbstractMultiWaySplitter(
+abstract class AbstractMultiWaySplitter
+constructor(
 	val splitPoints: List<Int>)
 {
 	/**

--- a/avail/src/main/kotlin/avail/interpreter/levelTwoSimple/L2SimpleInstruction.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwoSimple/L2SimpleInstruction.kt
@@ -40,6 +40,7 @@ import avail.AvailRuntime.HookType.RESULT_DISAGREED_WITH_EXPECTED_TYPE
 import avail.descriptor.bundles.A_Bundle
 import avail.descriptor.bundles.A_Bundle.Companion.bundleMethod
 import avail.descriptor.bundles.A_Bundle.Companion.numArgs
+import avail.descriptor.character.A_Character.Companion.codePoint
 import avail.descriptor.functions.A_Continuation
 import avail.descriptor.functions.A_Continuation.Companion.frameAt
 import avail.descriptor.functions.A_Continuation.Companion.frameAtPut
@@ -63,12 +64,19 @@ import avail.descriptor.methods.A_Method.Companion.lookupByValuesFromList
 import avail.descriptor.methods.A_Sendable.Companion.bodyBlock
 import avail.descriptor.methods.A_Sendable.Companion.isAbstractDefinition
 import avail.descriptor.methods.A_Sendable.Companion.isForwardDefinition
+import avail.descriptor.numbers.A_Number.Companion.extractInt
+import avail.descriptor.numbers.A_Number.Companion.extractLong
 import avail.descriptor.representation.AvailObject
 import avail.descriptor.representation.NilDescriptor.Companion.nil
 import avail.descriptor.tuples.A_Tuple
+import avail.descriptor.tuples.ByteTupleDescriptor.Companion.generateByteTupleFrom
+import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
+import avail.descriptor.tuples.LongTupleDescriptor.Companion.generateLongTupleFrom
+import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.generateNybbleTupleFrom
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.generateObjectTupleFrom
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tupleFromList
+import avail.descriptor.tuples.StringDescriptor.Companion.generateStringFromCodePoints
 import avail.descriptor.types.A_Type
 import avail.descriptor.types.A_Type.Companion.typeAtIndex
 import avail.descriptor.types.A_Type.Companion.typeUnion
@@ -89,6 +97,7 @@ import avail.exceptions.VariableGetException
 import avail.exceptions.VariableSetException
 import avail.interpreter.Primitive
 import avail.interpreter.Primitive.Flag
+import avail.interpreter.Primitive.Result.FAILURE
 import avail.interpreter.Primitive.Result.SUCCESS
 import avail.interpreter.execution.Interpreter
 import avail.interpreter.levelTwo.L1InstructionStepper
@@ -728,9 +737,118 @@ class L2Simple_MakeTupleN(
 	): StackReifier?
 	{
 		registers[to] = generateObjectTupleFrom(tupleSize) { i ->
-			val value = registers[to - i + 1]
-			value
+			registers[to - i + 1]
 		}
+		return null
+	}
+}
+
+/**
+ * Create an N-element tuple from `registers[to]`, `registers[to-1]`,...
+ * `registers[to-N+1]`, and write it back to `registers[to]`.  The registers are
+ * known to contain only nybbles.
+ */
+class L2Simple_MakeNybbleTupleN(
+	val tupleSize: Int,
+	val to: Int
+) : L2SimpleInstruction()
+{
+	override fun step(
+		registers: Array<AvailObject>,
+		interpreter: Interpreter
+	): StackReifier?
+	{
+		registers[to] = generateNybbleTupleFrom(tupleSize) { i ->
+			registers[to - i + 1].extractInt
+		}
+		return null
+	}
+}
+
+/**
+ * Create an N-element tuple from `registers[to]`, `registers[to-1]`,...
+ * `registers[to-N+1]`, and write it back to `registers[to]`.  The registers are
+ * known to contain only bytes.
+ */
+class L2Simple_MakeByteTupleN(
+	val tupleSize: Int,
+	val to: Int
+) : L2SimpleInstruction()
+{
+	override fun step(
+		registers: Array<AvailObject>,
+		interpreter: Interpreter
+	): StackReifier?
+	{
+		registers[to] = generateByteTupleFrom(tupleSize) { i ->
+			registers[to - i + 1].extractInt
+		}
+		return null
+	}
+}
+
+/**
+ * Create an N-element tuple from `registers[to]`, `registers[to-1]`,...
+ * `registers[to-N+1]`, and write it back to `registers[to]`.  The registers are
+ * known to contain only [Int]s.
+ */
+class L2Simple_MakeIntTupleN(
+	val tupleSize: Int,
+	val to: Int
+) : L2SimpleInstruction()
+{
+	override fun step(
+		registers: Array<AvailObject>,
+		interpreter: Interpreter
+	): StackReifier?
+	{
+		registers[to] = generateIntTupleFrom(tupleSize) { i ->
+			registers[to - i + 1].extractInt
+		}
+		return null
+	}
+}
+
+/**
+ * Create an N-element tuple from `registers[to]`, `registers[to-1]`,...
+ * `registers[to-N+1]`, and write it back to `registers[to]`.  The registers are
+ * known to contain only longs.
+ */
+class L2Simple_MakeLongTupleN(
+	val tupleSize: Int,
+	val to: Int
+) : L2SimpleInstruction()
+{
+	override fun step(
+		registers: Array<AvailObject>,
+		interpreter: Interpreter
+	): StackReifier?
+	{
+		registers[to] = generateLongTupleFrom(tupleSize) { i ->
+			registers[to - i + 1].extractLong
+		}
+		return null
+	}
+}
+
+/**
+ * Create an N-element tuple from `registers[to]`, `registers[to-1]`,...
+ * `registers[to-N+1]`, and write it back to `registers[to]`.  The registers are
+ * known to contain only characters.
+ */
+class L2Simple_MakeCharacterTupleN(
+	val tupleSize: Int,
+	val to: Int
+) : L2SimpleInstruction()
+{
+	override fun step(
+		registers: Array<AvailObject>,
+		interpreter: Interpreter
+	): StackReifier?
+	{
+		registers[to] = generateStringFromCodePoints(tupleSize) { i ->
+			registers[to - i + 1].codePoint
+		} as AvailObject
 		return null
 	}
 }
@@ -1266,7 +1384,7 @@ constructor(
  * Invoke a constant [A_Function], perhaps the result of a lookup that was
  * proven at translation time to be monomorphic.
  */
-class L2Simple_Invoke
+open class L2Simple_Invoke
 constructor(
 	stackp: Int,
 	pc: Int,
@@ -1300,6 +1418,70 @@ constructor(
 			args.add(registers[i])
 		}
 		return invocationHelper(interpreter, registers, function)
+	}
+}
+
+
+/**
+ * Execute an arbitrary Kotlin function that was provided by a [Primitive] for a
+ * particular call site.  The primitive may have chosen to bypass type checks
+ * that are known to statically hold, for example.  The function supplied by the
+ * primitive should either set the latestResult of the interpreter and return
+ * SUCCESS, or have no side-effect and return FAILURE.
+ *
+ * When the instruction is executed, first the function is invoked, and if it
+ * succeeds, the latestResult is written to the register at stackp, and the step
+ * is done.  Otherwise the function failed, so we do a general invocation, and
+ * assume the failed operation had no side-effect, so the general invocation's
+ * reattempt of the primitive shouldn't be harmful.  If a failed primitive would
+ * have a non-nilpotent side-effect, the primitive should answer a suitable
+ * Kotlin function that avoids that, or just null.
+ */
+class L2Simple_InvokeIfNilpotentAttemptFails
+constructor(
+	stackp: Int,
+	pc: Int,
+	nextOffset: Int,
+	liveIndices: Array<Int>,
+	expectedType: A_Type,
+	mustCheck: Boolean,
+	function: A_Function,
+	val nilpotentAttempt: (Interpreter)->Primitive.Result
+) : L2Simple_Invoke(
+	stackp,
+	pc,
+	nextOffset,
+	liveIndices,
+	expectedType,
+	mustCheck,
+	function)
+{
+	override fun step(
+		registers: Array<AvailObject>,
+		interpreter: Interpreter
+	): StackReifier?
+	{
+		val args = interpreter.argsBuffer
+		args.clear()
+		for (i in stackp downTo lastArgumentPosition)
+		{
+			args.add(registers[i])
+		}
+		interpreter.function = function
+		// First try the nilpotent function supplied by the primitive.
+		val result = nilpotentAttempt(interpreter)
+		interpreter.function = registers[0]
+		if (result === SUCCESS)
+		{
+			// By far the most common case: Fast path succeeded.  Record the
+			// returned value.
+			registers[stackp] = interpreter.getLatestResult()
+			return null
+		}
+		// Slower path: The primitive failed.  Fall back to L2Simple_Invoke's
+		// behavior, including retrying the primitive.
+		assert(result === FAILURE)
+		return super.step(registers, interpreter)
 	}
 }
 

--- a/avail/src/main/kotlin/avail/interpreter/levelTwoSimple/L2SimpleTranslator.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwoSimple/L2SimpleTranslator.kt
@@ -77,9 +77,15 @@ import avail.descriptor.types.A_Type.Companion.typeIntersection
 import avail.descriptor.types.A_Type.Companion.typeUnion
 import avail.descriptor.types.BottomTypeDescriptor.Companion.bottom
 import avail.descriptor.types.ContinuationTypeDescriptor.Companion.continuationTypeForFunctionType
+import avail.descriptor.types.IntegerRangeTypeDescriptor.Companion.i32
+import avail.descriptor.types.IntegerRangeTypeDescriptor.Companion.i64
+import avail.descriptor.types.IntegerRangeTypeDescriptor.Companion.u4
+import avail.descriptor.types.IntegerRangeTypeDescriptor.Companion.u8
+import avail.descriptor.types.PrimitiveTypeDescriptor.Types
 import avail.descriptor.types.TupleTypeDescriptor.Companion.tupleTypeForTypesList
 import avail.interpreter.Primitive.Fallibility.CallSiteCannotFail
 import avail.interpreter.Primitive.Flag.CanFold
+import avail.interpreter.Primitive.Result
 import avail.interpreter.execution.Interpreter
 import avail.interpreter.levelOne.L1OperationDispatcher
 import avail.interpreter.levelTwo.L2JVMChunk.Companion.unoptimizedChunk
@@ -268,7 +274,8 @@ constructor(
 	 * Answer the [TypeRestriction] that is guaranteed to hold for the return
 	 * value *after* it has been checked successfully against the expectedType.
 	 */
-	private fun generateGeneralInvocation(
+	fun generateGeneralInvocation(
+		nilpotentAttempt: ((Interpreter)->Result)?,
 		calledFunction: A_Function,
 		expectedType: A_Type
 	): TypeRestriction
@@ -313,15 +320,31 @@ constructor(
 			}
 			else -> calledCode.functionType().returnType
 		}
-		instructions.add(
-			L2Simple_Invoke(
-				stackp,
-				pc,
-				instructions.size + 1,
-				registerIndices,
-				expectedType,
-				!guaranteedReturnType.isSubtypeOf(expectedType),
-				calledFunction))
+		if (nilpotentAttempt !== null)
+		{
+			instructions.add(
+				L2Simple_InvokeIfNilpotentAttemptFails(
+					stackp,
+					pc,
+					instructions.size + 1,
+					registerIndices,
+					expectedType,
+					!guaranteedReturnType.isSubtypeOf(expectedType),
+					calledFunction,
+					nilpotentAttempt))
+		}
+		else
+		{
+			instructions.add(
+				L2Simple_Invoke(
+					stackp,
+					pc,
+					instructions.size + 1,
+					registerIndices,
+					expectedType,
+					!guaranteedReturnType.isSubtypeOf(expectedType),
+					calledFunction))
+		}
 		return boxedRestrictionForType(
 			guaranteedReturnType.typeIntersection(expectedType))
 	}
@@ -387,7 +410,7 @@ constructor(
 		{
 			// Nothing was generated, so fall back.
 			outputRestriction =
-				generateGeneralInvocation(calledFunction, expectedType)
+				generateGeneralInvocation(null, calledFunction, expectedType)
 		}
 		for (i in stackp - numArgs + 1 until stackp)
 		{
@@ -579,18 +602,31 @@ constructor(
 			restrictions[stackp] = boxedRestrictionForConstant(tuple)
 			return
 		}
-		add(
-			when (size)
-			{
-				0 -> L2Simple_MoveConstant(emptyTuple, stackp)
-				1 -> L2Simple_MakeTuple1(stackp)
-				2 -> L2Simple_MakeTuple2(stackp)
-				3 -> L2Simple_MakeTuple3(stackp)
-				else -> L2Simple_MakeTupleN(size, stackp)
-			})
 		val types = (stackp downTo  oldStackp).map {
 			restrictions[it].type
 		}
+		val elementType = types.fold(bottom) { a, b -> a.typeUnion(b) }
+		add(
+			when
+			{
+				size == 0 -> L2Simple_MoveConstant(emptyTuple, stackp)
+				elementType.isSubtypeOf(i64) -> when
+				{
+					elementType.isSubtypeOf(u4) ->
+						L2Simple_MakeNybbleTupleN(size, stackp)
+					elementType.isSubtypeOf(u8) ->
+						L2Simple_MakeByteTupleN(size, stackp)
+					elementType.isSubtypeOf(i32) ->
+						L2Simple_MakeIntTupleN(size, stackp)
+					else -> L2Simple_MakeLongTupleN(size, stackp)
+				}
+				elementType.isSubtypeOf(Types.CHARACTER.o) ->
+					L2Simple_MakeCharacterTupleN(size, stackp)
+				size == 1 -> L2Simple_MakeTuple1(stackp)
+				size == 2 -> L2Simple_MakeTuple2(stackp)
+				size == 3 -> L2Simple_MakeTuple3(stackp)
+				else -> L2Simple_MakeTupleN(size, stackp)
+			})
 		for (i in oldStackp until stackp)
 			restrictions[i] = nilRestriction
 		restrictions[stackp] =

--- a/avail/src/main/kotlin/avail/interpreter/primitive/controlflow/P_CatchException.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/controlflow/P_CatchException.kt
@@ -44,8 +44,8 @@ import avail.descriptor.types.A_Type.Companion.typeAtIndex
 import avail.descriptor.types.AbstractEnumerationTypeDescriptor.Companion.enumerationWith
 import avail.descriptor.types.BottomTypeDescriptor.Companion.bottom
 import avail.descriptor.types.FunctionTypeDescriptor.Companion.functionType
-import avail.descriptor.types.TupleTypeDescriptor.Companion.zeroOrMoreOf
 import avail.descriptor.types.PrimitiveTypeDescriptor.Types.TOP
+import avail.descriptor.types.TupleTypeDescriptor.Companion.zeroOrMoreOf
 import avail.descriptor.types.VariableTypeDescriptor.Companion.variableTypeFor
 import avail.descriptor.variables.VariableDescriptor.Companion.newVariableWithOuterType
 import avail.exceptions.AvailErrorCode.E_HANDLER_SENTINEL
@@ -76,9 +76,9 @@ object P_CatchException : Primitive(
 		interpreter: Interpreter): Result
 	{
 		interpreter.checkArgumentCount(3)
-		//val bodyBlock: A_Function = interpreter.argument(0);
+		//val bodyBlock: A_Function = interpreter.argument(0)
 		val handlerBlocks: A_Tuple = interpreter.argument(1)
-		//val ensureBlock: A_Function = interpreter.argument(2);
+		//val ensureBlock: A_Function = interpreter.argument(2)
 
 		val innerVariable = newVariableWithOuterType(failureVariableType)
 

--- a/avail/src/main/kotlin/avail/interpreter/primitive/objects/P_TupleToObject.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/objects/P_TupleToObject.kt
@@ -147,7 +147,8 @@ object P_TupleToObject : Primitive(1, CannotFail, CanFold, CanInline)
 		rawFunction: A_RawFunction,
 		arguments: List<L2ReadBoxedOperand>,
 		argumentTypes: List<A_Type>,
-		callSiteHelper: CallSiteHelper): Boolean
+		callSiteHelper: CallSiteHelper
+	): Boolean
 	{
 		// If we know the exact keys, we can statically determine the
 		// ObjectLayoutVariant to populate, and write the fields into the fixed

--- a/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicAddToMap.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicAddToMap.kt
@@ -32,17 +32,26 @@
 
 package avail.interpreter.primitive.variables
 
+import avail.descriptor.functions.A_Function
+import avail.descriptor.functions.A_RawFunction
 import avail.descriptor.methods.MethodDescriptor.SpecialMethodAtom
 import avail.descriptor.representation.NilDescriptor.Companion.nil
 import avail.descriptor.sets.SetDescriptor.Companion.set
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
 import avail.descriptor.types.A_Type
+import avail.descriptor.types.A_Type.Companion.isSubtypeOf
+import avail.descriptor.types.A_Type.Companion.keyType
+import avail.descriptor.types.A_Type.Companion.sizeRange
+import avail.descriptor.types.A_Type.Companion.upperBound
+import avail.descriptor.types.A_Type.Companion.valueType
+import avail.descriptor.types.A_Type.Companion.writeType
 import avail.descriptor.types.AbstractEnumerationTypeDescriptor.Companion.enumerationWith
 import avail.descriptor.types.BottomTypeDescriptor.Companion.bottom
 import avail.descriptor.types.FunctionTypeDescriptor.Companion.functionType
 import avail.descriptor.types.MapTypeDescriptor.Companion.mostGeneralMapType
 import avail.descriptor.types.PrimitiveTypeDescriptor.Types.ANY
 import avail.descriptor.types.PrimitiveTypeDescriptor.Types.TOP
+import avail.descriptor.types.VariableTypeDescriptor.Companion.mostGeneralVariableType
 import avail.descriptor.types.VariableTypeDescriptor.Companion.variableReadWriteType
 import avail.descriptor.variables.A_Variable
 import avail.exceptions.AvailErrorCode.E_CANNOT_READ_UNASSIGNED_VARIABLE
@@ -54,6 +63,8 @@ import avail.interpreter.Primitive.Flag.CanInline
 import avail.interpreter.Primitive.Flag.HasSideEffect
 import avail.interpreter.effects.LoadingEffectToRunPrimitive
 import avail.interpreter.execution.Interpreter
+import avail.interpreter.levelTwo.operand.TypeRestriction
+import avail.interpreter.levelTwoSimple.L2SimpleTranslator
 
 /**
  * **Primitive:** Atomically read and update the map in the specified
@@ -85,6 +96,46 @@ object P_AtomicAddToMap : Primitive(3, CanInline, HasSideEffect) {
 			LoadingEffectToRunPrimitive(
 				SpecialMethodAtom.ADD_TO_MAP_VARIABLE, variable, key, value))
 		return interpreter.primitiveSuccess(nil)
+	}
+
+	/**
+	 * Override to produce special code for this primitive, if it can be shown
+	 * statically that the value being written is of the correct type.
+	 */
+	override fun simplePrimitiveNilpotentInvocation(
+		simpleTranslator: L2SimpleTranslator,
+		functionIfKnown: A_Function?,
+		rawFunction: A_RawFunction,
+		argRestrictions: List<TypeRestriction>,
+		expectedType: A_Type
+	): ((Interpreter)->Result)?
+	{
+		val variableType = argRestrictions[0].type
+		val keyType = argRestrictions[1].type
+		val valueType = argRestrictions[2].type
+
+		assert(variableType.isSubtypeOf(mostGeneralVariableType))
+		val contentType = variableType.writeType
+		if (!contentType.isMapType) return null
+		if (!keyType.isSubtypeOf(contentType.keyType)) return null
+		if (!valueType.isSubtypeOf(contentType.valueType)) return null
+		if (contentType.sizeRange.upperBound.isFinite) return null
+		// The value being written doesn't need to be type checked at runtime.
+		return { interpreter ->
+			val (variable, newKey, newValue) = interpreter.argsBuffer
+			try {
+				variable.atomicAddToMapNoCheck(newKey, newValue)
+				interpreter.primitiveSuccess(nil)
+			}
+			catch (e: VariableGetException)
+			{
+				interpreter.primitiveFailure(e)
+			}
+			catch (e: VariableSetException)
+			{
+				interpreter.primitiveFailure(e)
+			}
+		}
 	}
 
 	override fun privateBlockTypeRestriction(): A_Type =

--- a/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicCompareAndSwap.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/variables/P_AtomicCompareAndSwap.kt
@@ -35,6 +35,7 @@ package avail.interpreter.primitive.variables
 import avail.descriptor.atoms.AtomDescriptor.Companion.falseObject
 import avail.descriptor.atoms.AtomDescriptor.Companion.objectFromBoolean
 import avail.descriptor.atoms.AtomDescriptor.Companion.trueObject
+import avail.descriptor.functions.A_Function
 import avail.descriptor.functions.A_RawFunction
 import avail.descriptor.sets.SetDescriptor.Companion.set
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
@@ -60,7 +61,9 @@ import avail.interpreter.Primitive.Flag.CanInline
 import avail.interpreter.Primitive.Flag.HasSideEffect
 import avail.interpreter.execution.Interpreter
 import avail.interpreter.levelTwo.operand.L2ReadBoxedOperand
+import avail.interpreter.levelTwo.operand.TypeRestriction
 import avail.interpreter.levelTwo.operation.L2_VARIABLE_COMPARE_AND_SWAP_NO_CHECK
+import avail.interpreter.levelTwoSimple.L2SimpleTranslator
 import avail.optimizer.L1Translator
 import avail.optimizer.L2Generator.Companion.edgeTo
 
@@ -139,6 +142,48 @@ object P_AtomicCompareAndSwap : Primitive(3, CanInline, HasSideEffect)
 			functionToCallReg, arguments, false, callSiteHelper)
 
 		return true
+	}
+
+	/**
+	 * Override to produce special code for this primitive, if it can be shown
+	 * statically that the value being written is of the correct type.
+	 */
+	override fun simplePrimitiveNilpotentInvocation(
+		simpleTranslator: L2SimpleTranslator,
+		functionIfKnown: A_Function?,
+		rawFunction: A_RawFunction,
+		argRestrictions: List<TypeRestriction>,
+		expectedType: A_Type
+	): ((Interpreter)->Result)?
+	{
+		val variableType = argRestrictions[0].type
+		//val referenceType = argRestrictions[1].type
+		val newValueType = argRestrictions[2].type
+
+		assert(variableType.isSubtypeOf(mostGeneralVariableType))
+		val contentType = variableType.writeType
+		if (!newValueType.isSubtypeOf(contentType))
+		{
+			return null
+		}
+		// The value being written doesn't need to be type checked at runtime.
+		return { interpreter ->
+			val (variable, reference, newValue) = interpreter.argsBuffer
+			try {
+				interpreter.primitiveSuccess(
+					objectFromBoolean(
+						variable.compareAndSwapValuesNoCheck(
+							reference, newValue)))
+			}
+			catch (e: VariableGetException)
+			{
+				interpreter.primitiveFailure(e)
+			}
+			catch (e: VariableSetException)
+			{
+				interpreter.primitiveFailure(e)
+			}
+		}
 	}
 
 	override fun privateBlockTypeRestriction(): A_Type =

--- a/avail/src/main/kotlin/avail/optimizer/L2Optimizer.kt
+++ b/avail/src/main/kotlin/avail/optimizer/L2Optimizer.kt
@@ -1969,7 +1969,7 @@ class L2Optimizer internal constructor(
 	companion object
 	{
 		/** Whether to sanity-check the graph between optimization steps. */
-		var shouldSanityCheck = true //TODO false
+		var shouldSanityCheck = false
 
 		/** Statistic for tracking the cost of sanity checks. */
 		private val sanityCheckStat = Statistic(

--- a/avail/src/main/kotlin/avail/optimizer/OptimizationPhase.kt
+++ b/avail/src/main/kotlin/avail/optimizer/OptimizationPhase.kt
@@ -233,6 +233,13 @@ internal enum class OptimizationPhase constructor(
 	ADJUST_EDGES_LEADING_TO_JUMPS(L2Optimizer::adjustEdgesLeadingToJumps),
 
 	/**
+	 * Find each branch instruction that has both of its outbound edges going to
+	 * the same target block.  Replace each such branch with a jump. Repeat
+	 * until there are no more such spurious branches remaining.
+	 */
+//	REMOVE_SPURIOUS_BRANCHING(L2Optimizer::removeSpuriousBranching),
+
+	/**
 	 * Having adjusted edges to avoid landing on [L2_JUMP]s, some blocks may
 	 * have become unreachable.
 	 */

--- a/avail/src/main/kotlin/avail/optimizer/jvm/JVMTranslator.kt
+++ b/avail/src/main/kotlin/avail/optimizer/jvm/JVMTranslator.kt
@@ -1952,7 +1952,7 @@ class JVMTranslator constructor(
 		 * what is generated when this flag is false), but it's probably not a
 		 * big difference.
 		 */
-		const val debugNicerJavaDecompilation = true
+		const val debugNicerJavaDecompilation = false
 
 		/**
 		 * A regex [Pattern] to rewrite function names like '"foo_"[1][3]' to


### PR DESCRIPTION
- Added optimizedTuple() for better singleton tuple kind.
- L2_CREATE_TUPLE also creates better tuple kind.
- Added L2SimpleInstruction subclasses for better tuple kind.
- The translation of an L1_doMakeTuple selects a suitably specific instruction, based on the static element types.
- Improved appendCanDestroy() for preserving tuple kind.
- Added L2Simple_InvokeIfNilpotentAttemptFails to allow fallible primitive call sites to produce a nilpotent function to be invoked first, falling back on a full call if it fails.
- Added atomicAddToMapNoCheck(), and updated P_AtomicAddToMap to use dt in L2Simple.  Same for P_AtomicCompareAndSwap.