### PR TITLE
Clawed back most of the remaining performance loss.

### DIFF
--- a/avail/src/main/kotlin/avail/descriptor/objects/ObjectDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/objects/ObjectDescriptor.kt
@@ -48,9 +48,11 @@ import avail.descriptor.objects.ObjectDescriptor.IntegerSlots.Companion.HASH_OR_
 import avail.descriptor.objects.ObjectDescriptor.IntegerSlots.HASH_AND_MORE
 import avail.descriptor.objects.ObjectDescriptor.ObjectSlots.FIELD_VALUES_
 import avail.descriptor.objects.ObjectDescriptor.ObjectSlots.KIND
+import avail.descriptor.objects.ObjectDescriptor.ObjectSlots.KNOWN_STATIC_OBJECT_TYPE
 import avail.descriptor.objects.ObjectDescriptor.ObjectSlots.TYPE_VETTINGS_CACHE
 import avail.descriptor.objects.ObjectLayoutVariant.Companion.variantForFields
 import avail.descriptor.objects.ObjectTypeDescriptor.Companion.namesAndBaseTypesForObjectType
+import avail.descriptor.objects.ObjectTypeDescriptor.TestOutcome
 import avail.descriptor.pojos.RawPojoDescriptor
 import avail.descriptor.pojos.RawPojoDescriptor.Companion.identityPojo
 import avail.descriptor.representation.A_BasicObject
@@ -82,6 +84,7 @@ import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tupleFromList
 import avail.descriptor.tuples.TupleDescriptor
 import avail.descriptor.types.A_Type
+import avail.descriptor.types.A_Type.Companion.checkAgainstObjectType
 import avail.descriptor.types.A_Type.Companion.fieldTypeMap
 import avail.descriptor.types.A_Type.Companion.hasObjectInstance
 import avail.descriptor.types.A_Type.Companion.isSupertypeOfPrimitiveTypeEnum
@@ -182,6 +185,13 @@ class ObjectDescriptor internal constructor(
 		TYPE_VETTINGS_CACHE,
 
 		/**
+		 * The [object type][ObjectTypeDescriptor] that this object was known to
+		 * conform to at the time of construction.
+		 */
+		@HideFieldInDebugger
+		KNOWN_STATIC_OBJECT_TYPE,
+
+		/**
 		 * The values associated with keys for this object.  The assignment of
 		 * object fields to these slots is determined by the descriptor's
 		 * [variant].
@@ -262,6 +272,7 @@ class ObjectDescriptor internal constructor(
 					.equals(anObject[FIELD_VALUES_, i]))
 				return false
 		}
+		// They're equal objects.
 		val kind = self[KIND].ifNil { anObject[KIND] }
 		if (!isShared)
 		{
@@ -329,11 +340,15 @@ class ObjectDescriptor internal constructor(
 					}
 					@Suppress("MapGetWithNotNullAssertionOperator")
 					val newVariantSlotIndex = newVariantSlotMap[field]!!
-					if (newVariantSlotIndex != 0) {
+					if (newVariantSlotIndex != 0)
+					{
 						setSlot(FIELD_VALUES_, newVariantSlotIndex, value)
 					}
 					setSlot(KIND, nil)
 					setSlot(TYPE_VETTINGS_CACHE, nil)
+					setSlot(
+						KNOWN_STATIC_OBJECT_TYPE,
+						newVariant.mostGeneralObjectType)
 					setSlot(HASH_OR_ZERO, 0)
 				}
 			}
@@ -343,13 +358,16 @@ class ObjectDescriptor internal constructor(
 			}
 			else -> {
 				// Replace an existing real field.
-				return when {
+				return when
+				{
 					canDestroy && isMutable -> self
 					else -> newLike(variant.mutableObjectDescriptor, self, 0, 0)
 				}.apply {
 					setSlot(FIELD_VALUES_, slotIndex, value)
 					setSlot(KIND, nil)
 					setSlot(TYPE_VETTINGS_CACHE, nil)
+					setSlot(
+						KNOWN_STATIC_OBJECT_TYPE, variant.mostGeneralObjectType)
 					setSlot(HASH_OR_ZERO, 0)
 				}
 			}
@@ -357,7 +375,6 @@ class ObjectDescriptor internal constructor(
 	}
 
 	override fun o_FieldMap(self: AvailObject): A_Map =
-		// Warning: May be much slower than it was before ObjectLayoutVariant.
 		variant.fieldToSlotIndex.entries.fold(emptyMap) {
 			map, (field, slotIndex) ->
 			map.mapAtPuttingCanDestroy(
@@ -398,6 +415,17 @@ class ObjectDescriptor internal constructor(
 		if (typeDescriptor !is ObjectTypeDescriptor) return false
 		if (!typeDescriptor.isShared)
 			return typeTraversed.hasObjectInstance(self)
+
+		// Check with the static type captured at the creatien site.
+		val knownStaticType = self[KNOWN_STATIC_OBJECT_TYPE]
+		// The object definitely satisfies knownStaticType, so see if aType is
+		// a supertype of it or disjoint to it.
+		when (knownStaticType.checkAgainstObjectType(typeTraversed))
+		{
+			TestOutcome.SUPER -> return true
+			TestOutcome.DISJOINT -> return false
+			TestOutcome.UNDETERMINED -> {}
+		}
 
 		// At this point, either a VettingsCache already exists, or one will be
 		// needed to store the positive/negative result.
@@ -567,7 +595,8 @@ class ObjectDescriptor internal constructor(
 
 		/**
 		 * Update the field value at the specified slot index of the mutable
-		 * object.
+		 * object.  This is intended to be used during object construction, so
+		 * DO NOT clear or compute the hash, or change any other slots.
 		 *
 		 * @param self
 		 *   An object.
@@ -623,6 +652,7 @@ class ObjectDescriptor internal constructor(
 				}
 				setSlot(KIND, nil)
 				setSlot(TYPE_VETTINGS_CACHE, nil)
+				setSlot(KNOWN_STATIC_OBJECT_TYPE, variant.mostGeneralObjectType)
 				setSlot(HASH_OR_ZERO, 0)
 			}
 		}
@@ -661,17 +691,22 @@ class ObjectDescriptor internal constructor(
 		 *
 		 * @param variant
 		 *   The [ObjectLayoutVariant] to instantiate as an object.
+		 * @param guaranteedType
+		 *   An [A_Type] (using [ObjectTypeDescriptor]) that the resulting
+		 *   object is statically guarnteed to satisfy.
 		 * @return
 		 *   The new object.
 		 */
 		@ReferencedInGeneratedCode
 		@JvmStatic
 		fun createUninitializedObject(
-			variant: ObjectLayoutVariant
+			variant: ObjectLayoutVariant,
+			guaranteedType: A_Type,
 		): AvailObject =
 			variant.mutableObjectDescriptor.create(variant.realSlotCount) {
 				setSlot(KIND, nil)
 				setSlot(TYPE_VETTINGS_CACHE, nil)
+				setSlot(KNOWN_STATIC_OBJECT_TYPE, guaranteedType)
 				setSlot(HASH_OR_ZERO, 0)
 			}
 
@@ -682,7 +717,8 @@ class ObjectDescriptor internal constructor(
 			ObjectDescriptor::class.java,
 			::createUninitializedObject.name,
 			AvailObject::class.java,
-			ObjectLayoutVariant::class.java)
+			ObjectLayoutVariant::class.java,
+			A_Type::class.java)
 
 		/**
 		 * Produce the given object's [ObjectLayoutVariant]'s variantId.

--- a/avail/src/main/kotlin/avail/descriptor/objects/ObjectTypeDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/objects/ObjectTypeDescriptor.kt
@@ -55,6 +55,12 @@ import avail.descriptor.maps.MapDescriptor.Companion.emptyMap
 import avail.descriptor.objects.ObjectLayoutVariant.Companion.variantForFields
 import avail.descriptor.objects.ObjectTypeDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.objects.ObjectTypeDescriptor.ObjectSlots.FIELD_TYPES_
+import avail.descriptor.objects.ObjectTypeDescriptor.ObjectSlots.TESTING_TYPES_POJO
+import avail.descriptor.objects.ObjectTypeDescriptor.ObjectSlots.WEAK_REFERENCE_POJO
+import avail.descriptor.objects.ObjectTypeDescriptor.TestOutcome.DISJOINT
+import avail.descriptor.objects.ObjectTypeDescriptor.TestOutcome.SUPER
+import avail.descriptor.objects.ObjectTypeDescriptor.TestOutcome.UNDETERMINED
+import avail.descriptor.pojos.RawPojoDescriptor.Companion.identityPojo
 import avail.descriptor.representation.A_BasicObject
 import avail.descriptor.representation.A_BasicObject.Companion.objectVariant
 import avail.descriptor.representation.AbstractDescriptor.Companion.staticTypeTagOrdinal
@@ -67,6 +73,7 @@ import avail.descriptor.representation.AvailObjectFieldHelper
 import avail.descriptor.representation.BitField
 import avail.descriptor.representation.IntegerSlotsEnum
 import avail.descriptor.representation.Mutability
+import avail.descriptor.representation.Mutability.SHARED
 import avail.descriptor.representation.NilDescriptor.Companion.nil
 import avail.descriptor.representation.ObjectSlotsEnum
 import avail.descriptor.sets.A_Set
@@ -165,7 +172,25 @@ class ObjectTypeDescriptor internal constructor(
 	/**
 	 * The layout of object slots for my instances.
 	 */
-	enum class ObjectSlots : ObjectSlotsEnum {
+	enum class ObjectSlots : ObjectSlotsEnum
+	{
+		/**
+		 * A POJO holding a reusable weak reference to this object type.  This
+		 * only gets populated when making the object type shared (and only if
+		 * it doesn't simply become an indirection to an existing equal one).
+		 */
+		WEAK_REFERENCE_POJO,
+
+		/**
+		 * A pojo holding an [Array], initially empty, of [Pair]s tying together
+		 * other object types that have been tested with the [TestOutcome]s.
+		 * This array is update with volatile semantics, which is far cheaper
+		 * than compare-and-set loops, and at most causes some test outcomes to
+		 * be dropped in the event of a conflict, requiring an additional test
+		 * in those rare cases.
+		 */
+		TESTING_TYPES_POJO,
+
 		/**
 		 * The types associated with keys for this object.  The assignment of
 		 * object fields to these slots is determined by the descriptor's
@@ -174,10 +199,34 @@ class ObjectTypeDescriptor internal constructor(
 		FIELD_TYPES_
 	}
 
+	/**
+	 * The result of a comparison of two [SHARED] object types, for use in the
+	 * first one's [TESTING_TYPES_POJO] map.  There isn't an entry for `subtype`, since
+	 * for this usage we're only interested in whether the second type
+	 * definitely is or cannot be a supertype of the first.
+	 */
+	enum class TestOutcome
+	{
+		/** The second object type is a super of the first. */
+		SUPER,
+
+		/**
+		 * The two object types are unrelated – they have a nearest common
+		 * descendent of ⊥.
+		 */
+		DISJOINT,
+
+		/**
+		 * The two object types don't have an obviouus relation to each other.
+		 */
+		UNDETERMINED
+	}
+
 	public override fun allowsImmutableToMutableReferenceInField(
 		e: AbstractSlotsEnum
-	) =
-		e === IntegerSlots.HASH_AND_MORE
+	) = e === IntegerSlots.HASH_AND_MORE
+		|| e === ObjectSlots.WEAK_REFERENCE_POJO
+		|| e === ObjectSlots.TESTING_TYPES_POJO
 
 	override fun printObjectOnAvoidingIndent(
 		self: AvailObject,
@@ -237,6 +286,58 @@ class ObjectTypeDescriptor internal constructor(
 			}
 			append("\n#}")
 		}
+	}
+
+	override fun o_CheckAgainstObjectType(
+		self: AvailObject,
+		otherObjectType: A_Type
+	): TestOutcome
+	{
+		// First, see if we've already checked this combination of types.
+		val otherHash = otherObjectType.hash()
+		val testResults: Array<Pair<WeakObjectTypeReference, TestOutcome>> =
+			self.volatileSlot(TESTING_TYPES_POJO).javaObjectNotNull()
+		for (result in testResults)
+		{
+			if (result.first.hash == otherHash)
+			{
+				// It's almost certainly the object type we're looking for.
+				val otherTypeInPair = result.first.get()
+				if (otherTypeInPair !== null
+					&& (otherTypeInPair === otherObjectType
+						|| otherTypeInPair.equals(otherObjectType)))
+				{
+					return result.second
+				}
+			}
+		}
+		// None of the cached tests results was applicable.
+		val outcome = when
+		{
+			self.isSubtypeOf(otherObjectType) -> SUPER
+			self.typeIntersection(otherObjectType).isBottom -> DISJOINT
+			else -> UNDETERMINED
+		}
+		val otherStrong = otherObjectType.traversed()
+		val otherReference: WeakObjectTypeReference =
+			otherStrong[WEAK_REFERENCE_POJO].javaObjectNotNull()
+		val newList = testResults.filterTo(
+			mutableListOf(otherReference to outcome)
+		) { it.first.get() !== null }
+		if (newList.size > maximumTestOutcomesToKeep)
+		{
+			// Trim it down to no more than trimmedOutcomesSize elements.
+			newList.subList(trimmedOutcomesSize, newList.size).clear()
+		}
+		// This may be racing against other threads that are adding to the
+		// array, but each write is making progress relative to its own starting
+		// point.  That at least guarantees there are no duplicate values in the
+		// array, and that after all threads running this method have returned,
+		// any new threads can only extend the array (not counting the
+		// truncation).
+		self[TESTING_TYPES_POJO] =
+			identityPojo(newList.toTypedArray()).makeShared()
+		return outcome
 	}
 
 	/**
@@ -460,15 +561,23 @@ class ObjectTypeDescriptor internal constructor(
 			{
 				canonical = synchronized(sharedCanonicalTypes) {
 					sharedCanonicalTypes.getOrPut(self) {
-						WeakObjectTypeReference(self)
+						val ref = WeakObjectTypeReference(self)
+						// Note that even though the weakReference field is not
+						// volatile, it won't be accessed unless self is shared,
+						// which can only happen in this thread or after the
+						// enclosding  synchronized section completes.
+						val refPojo = identityPojo(ref)
+						refPojo.setDescriptor(refPojo.descriptor().shared())
+						queueToProcess.add(refPojo)
+						self.setVolatileSlot(WEAK_REFERENCE_POJO, refPojo)
+						ref
 					}.get()
 				}
 				// An older weak reference might have been found, then cleared
 				// by the JVM.  Just try again until we're successful (and
 				// therefore have a strong reference that prevents it from
 				// dissolving).
-			}
-			while (canonical === null)
+			} while (canonical === null)
 			if (!canonical.sameAddressAs(self))
 			{
 				// Indirect self to be the canonical value.  This is safe
@@ -520,9 +629,7 @@ class ObjectTypeDescriptor internal constructor(
 		val otherVariant = anObjectType.objectTypeVariant
 		if (otherVariant == variant) {
 			// Field slot indices agree, so blast through the slots in order.
-			return variant.mutableObjectTypeDescriptor.create(
-				variant.realSlotCount
-			) {
+			return createUninitializedObjectType(variant) {
 				(1..variant.realSlotCount).forEach {
 					val fieldIntersection =
 						self[FIELD_TYPES_, it].typeIntersection(
@@ -533,7 +640,6 @@ class ObjectTypeDescriptor internal constructor(
 					}
 					setSlot(FIELD_TYPES_, it, fieldIntersection)
 				}
-				setSlot(HASH_OR_ZERO, 0)
 			}
 		}
 		// The variants disagree, so do it the hard(er) way.
@@ -543,9 +649,7 @@ class ObjectTypeDescriptor internal constructor(
 		val mySlotMap = variant.fieldToSlotIndex
 		val otherSlotMap = otherVariant.fieldToSlotIndex
 		val resultSlotMap = resultVariant.fieldToSlotIndex
-		return resultVariant.mutableObjectTypeDescriptor.create(
-			resultVariant.realSlotCount
-		) {
+		return createUninitializedObjectType(resultVariant) {
 			resultSlotMap.forEach { (field, resultSlotIndex) ->
 				if (resultSlotIndex > 0)
 				{
@@ -569,7 +673,6 @@ class ObjectTypeDescriptor internal constructor(
 					setSlot(FIELD_TYPES_, resultSlotIndex, fieldType)
 				}
 			}
-			setSlot(HASH_OR_ZERO, 0)
 		}
 	}
 
@@ -593,15 +696,12 @@ class ObjectTypeDescriptor internal constructor(
 		val otherVariant = anObjectType.objectTypeVariant
 		if (otherVariant == variant) {
 			// Field slot indices agree, so blast through the slots in order.
-			return variant.mutableObjectTypeDescriptor.create(
-				variant.realSlotCount
-			) {
+			return createUninitializedObjectType(variant) {
 				(1..variant.realSlotCount).forEach {
 					val fieldUnion = self[FIELD_TYPES_, it].typeUnion(
 						anObjectType[FIELD_TYPES_, it])
 					setSlot(FIELD_TYPES_, it, fieldUnion)
 				}
-				setSlot(HASH_OR_ZERO, 0)
 			}
 		}
 		// The variants disagree, so do it the hard(er) way.
@@ -611,9 +711,7 @@ class ObjectTypeDescriptor internal constructor(
 		val mySlotMap = variant.fieldToSlotIndex
 		val otherSlotMap = otherVariant.fieldToSlotIndex
 		val resultSlotMap = resultVariant.fieldToSlotIndex
-		return resultVariant.mutableObjectTypeDescriptor.create(
-			resultVariant.realSlotCount
-		) {
+		return createUninitializedObjectType(resultVariant) {
 			resultSlotMap.forEach { (field, resultSlotIndex) ->
 				if (resultSlotIndex > 0)
 				{
@@ -626,7 +724,6 @@ class ObjectTypeDescriptor internal constructor(
 					setSlot(FIELD_TYPES_, resultSlotIndex, fieldType)
 				}
 			}
-			setSlot(HASH_OR_ZERO, 0)
 		}
 	}
 
@@ -663,12 +760,11 @@ class ObjectTypeDescriptor internal constructor(
 	 *   An object type.
 	 */
 	fun createFromObject(self: AvailObject): AvailObject =
-		create(variant.realSlotCount) {
+		createUninitializedObjectType(variant) {
 			(1..variant.realSlotCount).forEach {
 				val fieldValue = ObjectDescriptor.getField(self, it)
 				setSlot(FIELD_TYPES_, it, instanceTypeOrMetaOn(fieldValue))
 			}
-			setSlot(HASH_OR_ZERO, 0)
 		}
 
 	@Deprecated(
@@ -699,6 +795,35 @@ class ObjectTypeDescriptor internal constructor(
 			WeakHashMap<AvailObject, WeakObjectTypeReference>()
 
 		/**
+		 * An empty (and therefore immutable) [Array] of [Pair]s tying together
+		 * a (weak reference to an) object type and a [TestOutcome].  This is
+		 * the initial value of the [TESTING_TYPES_POJO] field, replaced with
+		 * volatile semantics with a larger array as tests take place.
+		 */
+		val emptyTestedTypesArrayPojo =
+			identityPojo(arrayOf<Pair<WeakObjectTypeReference, TestOutcome>>())
+				.makeShared()
+
+		/**
+		 * The maximum size of the [TESTING_TYPES_POJO] array in an object type.
+		 */
+		const val maximumTestOutcomesToKeep = 50
+
+		/**
+		 * The maximum number of elements of the [TESTING_TYPES_POJO] array to
+		 * keep when it would grow too large, after also removing any weak
+		 * references whose referent has been collected.  Must be less than
+		 * [maximumTestOutcomesToKeep].
+		 */
+		const val trimmedOutcomesSize = 30
+
+		init
+		{
+			assert(trimmedOutcomesSize < maximumTestOutcomesToKeep)
+		}
+
+
+		/**
 		 * Extract the field type at the specified slot index.
 		 *
 		 * @param self
@@ -725,11 +850,9 @@ class ObjectTypeDescriptor internal constructor(
 		 */
 		fun objectTypeFromMap(map: A_Map): AvailObject {
 			val variant: ObjectLayoutVariant = variantForFields(map.keysAsSet)
-			val mutableDescriptor = variant.mutableObjectTypeDescriptor
 			val slotMap = variant.fieldToSlotIndex
-			return mutableDescriptor.create(variant.realSlotCount) {
+			return createUninitializedObjectType(variant) {
 				map.forEach { key, value ->
-					@Suppress("MapGetWithNotNullAssertionOperator")
 					val slotIndex = slotMap[key]!!
 					if (slotIndex > 0) {
 						setSlot(FIELD_TYPES_, slotIndex, value)
@@ -761,15 +884,18 @@ class ObjectTypeDescriptor internal constructor(
 		 * caller is responsible for initializing the fields before use.
 		 *
 		 * @param variant
-		 * The [ObjectLayoutVariant] to instantiate as an object type.
+		 *    The [ObjectLayoutVariant] to instantiate as an object type.
 		 * @return The new object type.
 		 */
-		@Suppress("unused")
-		fun createUninitializedObjectType(
-			variant: ObjectLayoutVariant
+		inline fun createUninitializedObjectType(
+			variant: ObjectLayoutVariant,
+			init: AvailObject.()->Unit = { }
 		): AvailObject =
 			variant.mutableObjectTypeDescriptor.create(variant.realSlotCount) {
+				setSlot(WEAK_REFERENCE_POJO, nil)
+				setSlot(TESTING_TYPES_POJO, emptyTestedTypesArrayPojo)
 				setSlot(HASH_OR_ZERO, 0)
+				init()
 			}
 
 		/** A lock for accessing information about object type names. */

--- a/avail/src/main/kotlin/avail/descriptor/objects/VettingsCache.kt
+++ b/avail/src/main/kotlin/avail/descriptor/objects/VettingsCache.kt
@@ -84,9 +84,9 @@ class VettingsCache
 	var negativeCache2 = emptyArray
 
 	/**
-	 * Test if [theObject], which is instantiation of [ObjectDescriptor], is an
-	 * instance of [objectType], which is a [Mutability.SHARED] instantiation of
-	 * [ObjectTypeDescriptor].  The receiver is [theObject]'s vettings cache,
+	 * Test if [theObject], which is an instantiation of [ObjectDescriptor], is
+	 * an instance of [objectType], which is a [Mutability.SHARED] instantiation
+	 * of [ObjectTypeDescriptor].  The receiver is [theObject]'s vettings cache,
 	 * and may be updated by this test.
 	 */
 	fun testObjectAgainstType(

--- a/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/AbstractDescriptor.kt
@@ -101,6 +101,7 @@ import avail.descriptor.numbers.AbstractNumberDescriptor.Sign
 import avail.descriptor.numbers.InfinityDescriptor
 import avail.descriptor.numbers.IntegerDescriptor
 import avail.descriptor.objects.ObjectLayoutVariant
+import avail.descriptor.objects.ObjectTypeDescriptor
 import avail.descriptor.parsing.A_DefinitionParsingPlan
 import avail.descriptor.parsing.A_Lexer
 import avail.descriptor.parsing.A_ParsingPlanInProgress
@@ -1064,6 +1065,11 @@ abstract class AbstractDescriptor protected constructor (
 	abstract fun o_BinElementAt (self: AvailObject, index: Int): AvailObject
 
 	abstract fun o_BuildFilteredBundleTree (self: AvailObject): A_BundleTree
+
+	abstract fun o_CheckAgainstObjectType(
+		self: AvailObject,
+		otherObjectType: A_Type
+	): ObjectTypeDescriptor.TestOutcome
 
 	/**
 	 * Compare a subrange of the [receiver][AvailObject] with a subrange of

--- a/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/Descriptor.kt
@@ -69,6 +69,7 @@ import avail.descriptor.numbers.AbstractNumberDescriptor.Order
 import avail.descriptor.numbers.AbstractNumberDescriptor.Sign
 import avail.descriptor.numbers.IntegerDescriptor
 import avail.descriptor.objects.ObjectLayoutVariant
+import avail.descriptor.objects.ObjectTypeDescriptor
 import avail.descriptor.parsing.A_DefinitionParsingPlan
 import avail.descriptor.parsing.A_Lexer
 import avail.descriptor.parsing.A_ParsingPlanInProgress
@@ -345,6 +346,11 @@ protected constructor (
 
 	override fun o_BuildFilteredBundleTree (self: AvailObject): A_BundleTree =
 		unsupported
+
+	override fun o_CheckAgainstObjectType (
+		self: AvailObject,
+		otherObjectType: A_Type
+	): ObjectTypeDescriptor.TestOutcome = unsupported
 
 	override fun o_CompareFromToWithStartingAt (
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/IndirectionDescriptor.kt
@@ -363,6 +363,7 @@ import avail.descriptor.numbers.A_Number.Companion.whichPowerOfTwo
 import avail.descriptor.numbers.AbstractNumberDescriptor
 import avail.descriptor.numbers.AbstractNumberDescriptor.Sign
 import avail.descriptor.objects.ObjectLayoutVariant
+import avail.descriptor.objects.ObjectTypeDescriptor
 import avail.descriptor.parsing.A_DefinitionParsingPlan
 import avail.descriptor.parsing.A_DefinitionParsingPlan.Companion.definition
 import avail.descriptor.parsing.A_DefinitionParsingPlan.Companion.parsingInstructions
@@ -522,6 +523,7 @@ import avail.descriptor.types.A_Type.Companion.acceptsListOfArgValues
 import avail.descriptor.types.A_Type.Companion.acceptsTupleOfArgTypes
 import avail.descriptor.types.A_Type.Companion.acceptsTupleOfArguments
 import avail.descriptor.types.A_Type.Companion.argsTupleType
+import avail.descriptor.types.A_Type.Companion.checkAgainstObjectType
 import avail.descriptor.types.A_Type.Companion.computeInstanceTag
 import avail.descriptor.types.A_Type.Companion.computeSuperkind
 import avail.descriptor.types.A_Type.Companion.contentType
@@ -1035,6 +1037,11 @@ class IndirectionDescriptor private constructor(
 	override fun o_BuildFilteredBundleTree(
 		self: AvailObject
 	): A_BundleTree = self .. { buildFilteredBundleTree() }
+
+	override fun o_CheckAgainstObjectType(
+		self: AvailObject,
+		otherObjectType: A_Type
+	): ObjectTypeDescriptor.TestOutcome = self .. { checkAgainstObjectType(otherObjectType) }
 
 	override fun o_CompareFromToWithStartingAt(
 		self: AvailObject,

--- a/avail/src/main/kotlin/avail/descriptor/representation/NilDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/representation/NilDescriptor.kt
@@ -57,15 +57,14 @@ private constructor() : Descriptor(
 	@ThreadSafe
 	override fun o_Equals(
 		self: AvailObject, another: A_BasicObject
-	): Boolean {
-		return another.isNil
-	}
+	): Boolean = another.isNil
 
 	@ThreadSafe
 	override fun o_Hash(self: AvailObject): Int {
 		// Nil should hash to zero, because the only place it can appear in a
 		// data structure is as a placeholder object. This currently (as of July
-		// 1998) applies to sets, maps, variables, and continuations.
+		// 1998) applies to sets, maps, variables, and continuations.  [As of
+		// well before 2024, this no longer applies to map bins].
 		return 0
 	}
 
@@ -81,8 +80,8 @@ private constructor() : Descriptor(
 		self: AvailObject,
 		builder: StringBuilder,
 		recursionMap: IdentityHashMap<A_BasicObject, Void>,
-		indent: Int
-	) {
+		indent: Int)
+	{
 		builder.append("nil")
 	}
 
@@ -92,7 +91,8 @@ private constructor() : Descriptor(
 
 	override fun shared() = shared
 
-	companion object {
+	companion object
+	{
 		/** The shared [NilDescriptor]. */
 		private val shared = NilDescriptor()
 

--- a/avail/src/main/kotlin/avail/descriptor/tuples/ByteTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/ByteTupleDescriptor.kt
@@ -54,9 +54,12 @@ import avail.descriptor.tuples.A_Tuple.Companion.treeTupleLevel
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAtPuttingCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleIntAt
+import avail.descriptor.tuples.A_Tuple.Companion.tupleLongAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.ByteTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.ByteTupleDescriptor.IntegerSlots.RAW_LONG_AT_
+import avail.descriptor.tuples.IntTupleDescriptor.Companion.generateIntTupleFrom
+import avail.descriptor.tuples.LongTupleDescriptor.Companion.generateLongTupleFrom
 import avail.descriptor.tuples.NybbleTupleDescriptor.Companion.mutableObjectOfSize
 import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.types.A_Type
@@ -294,6 +297,22 @@ private constructor(
 			}
 			result[HASH_OR_ZERO] = 0
 			return result
+		}
+		if (otherTuple.isIntTuple && newSize <= maximumCopySize)
+		{
+			// bytes ++ ints -> ints
+			return generateIntTupleFrom(newSize) {
+				if (it <= size1) self.tupleIntAt(it)
+				else otherTuple.tupleIntAt(it - size1)
+			}
+		}
+		if (otherTuple.isLongTuple && newSize <= maximumCopySize)
+		{
+			// bytes ++ longs -> longs
+			return generateLongTupleFrom(newSize) {
+				if (it <= size1) self.tupleLongAt(it)
+				else otherTuple.tupleLongAt(it - size1)
+			}
 		}
 		if (!canDestroy)
 		{

--- a/avail/src/main/kotlin/avail/descriptor/tuples/IntTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/IntTupleDescriptor.kt
@@ -56,6 +56,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.treeTupleLevel
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleAtPuttingCanDestroy
 import avail.descriptor.tuples.A_Tuple.Companion.tupleIntAt
+import avail.descriptor.tuples.A_Tuple.Companion.tupleLongAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
 import avail.descriptor.tuples.IntTupleDescriptor.IntegerSlots.Companion.HASH_OR_ZERO
 import avail.descriptor.tuples.IntTupleDescriptor.IntegerSlots.RAW_LONG_AT_
@@ -327,6 +328,14 @@ private constructor(
 			}
 			result[HASH_OR_ZERO] = 0
 			return result
+		}
+		if (otherTuple.isLongTuple && newSize <= maximumCopySize)
+		{
+			// ints ++ longs -> longs
+			return generateLongTupleFrom(newSize) {
+				if (it <= size1) self.tupleIntAt(it).toLong()
+				else otherTuple.tupleLongAt(it - size1)
+			}
 		}
 		if (!canDestroy)
 		{

--- a/avail/src/main/kotlin/avail/descriptor/tuples/LongTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/LongTupleDescriptor.kt
@@ -154,7 +154,7 @@ private constructor(
 		}
 		val longValue = newElementStrong.extractLong
 		val newSize = originalSize + 1
-		// always copy to a larger LongTupleDescriptor.
+		// Always copy to a larger LongTupleDescriptor.
 		val result = newLike(mutable, self, 0, 1)
 		result[LONG_AT_, newSize] = longValue
 		result[HASH_OR_ZERO] = 0
@@ -249,7 +249,8 @@ private constructor(
 			return self
 		}
 		val newSize = size1 + size2
-		if (otherTuple.isLongTuple && newSize <= maximumCopySize)
+		if (otherTuple.traversed().descriptor() is NumericTupleDescriptor
+			&& newSize <= maximumCopySize)
 		{
 			// Copy the longs.
 			val deltaSlots = newSize - self.variableIntegerSlotsCount()

--- a/avail/src/main/kotlin/avail/descriptor/tuples/NybbleTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/NybbleTupleDescriptor.kt
@@ -355,7 +355,6 @@ private constructor(
 			var src = 1
 			while (src <= size2)
 			{
-
 				// If the slots we want are nybbles then we won't have to copy
 				// into a bulkier representation.
 				result = result.tupleAtPuttingCanDestroy(

--- a/avail/src/main/kotlin/avail/descriptor/tuples/StringDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/StringDescriptor.kt
@@ -274,8 +274,7 @@ abstract class StringDescriptor protected constructor(
 						representationLimit = maxCodePointInt
 					}
 				}
-				string = string.tupleAtPuttingCanDestroy(
-					i, character, true)
+				string = string.tupleAtPuttingCanDestroy(i, character, true)
 			}
 			return string as A_String
 		}

--- a/avail/src/main/kotlin/avail/descriptor/tuples/TreeTupleDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/tuples/TreeTupleDescriptor.kt
@@ -59,7 +59,7 @@ import avail.descriptor.tuples.A_Tuple.Companion.tupleIntAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleLongAt
 import avail.descriptor.tuples.A_Tuple.Companion.tupleReverse
 import avail.descriptor.tuples.A_Tuple.Companion.tupleSize
-import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.tuple
+import avail.descriptor.tuples.ObjectTupleDescriptor.Companion.optimizedTuple
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.maxWidth
 import avail.descriptor.tuples.TreeTupleDescriptor.Companion.minWidthOfNonRoot
 import avail.descriptor.tuples.TreeTupleDescriptor.IntegerSlots.CUMULATIVE_SIZES_AREA_
@@ -156,8 +156,11 @@ class TreeTupleDescriptor internal constructor(
 	override fun o_AppendCanDestroy(
 		self: AvailObject,
 		newElement: A_BasicObject,
-		canDestroy: Boolean): A_Tuple =
-			concatenateAtLeastOneTree(self, tuple(newElement), canDestroy)
+		canDestroy: Boolean
+	): A_Tuple = concatenateAtLeastOneTree(
+		self,
+		optimizedTuple(newElement as AvailObject),
+		canDestroy)
 
 	/**
 	 * Answer approximately how many bits per entry are taken up by this object.

--- a/avail/src/main/kotlin/avail/descriptor/types/A_Type.kt
+++ b/avail/src/main/kotlin/avail/descriptor/types/A_Type.kt
@@ -193,6 +193,17 @@ interface A_Type : A_BasicObject
 			get() = dispatch { o_ArgsTupleType(it) }
 
 		/**
+		 * Compare two *object types* ([ObjectTypeDescriptor]).  Answer the result true if
+		 * the receiver is a subtype of [otherObjectType], answer false if the
+		 * receiver is disjoint from [otherObjectType] (i.e., their intersection
+		 * is ⊥), and otherwise answer `null`.
+		 */
+		fun A_Type.checkAgainstObjectType(
+			otherObjectType: A_Type
+		): ObjectTypeDescriptor.TestOutcome =
+			dispatch { o_CheckAgainstObjectType(it, otherObjectType) }
+
+		/**
 		 * Given an [A_Type], compute the most specific [TypeTag] that is
 		 * ensured for instances of that type.
 		 *

--- a/avail/src/main/kotlin/avail/descriptor/types/FunctionTypeDescriptor.kt
+++ b/avail/src/main/kotlin/avail/descriptor/types/FunctionTypeDescriptor.kt
@@ -40,7 +40,6 @@ import avail.descriptor.numbers.A_Number.Companion.isInt
 import avail.descriptor.numbers.A_Number.Companion.lessThan
 import avail.descriptor.objects.ObjectTypeDescriptor
 import avail.descriptor.representation.A_BasicObject
-import avail.descriptor.representation.A_BasicObject.Companion.synchronizeIf
 import avail.descriptor.representation.AbstractSlotsEnum
 import avail.descriptor.representation.AvailObject
 import avail.descriptor.representation.BitField
@@ -117,13 +116,15 @@ import java.util.IdentityHashMap
  * @param mutability
  *   The [mutability][Mutability] of the new descriptor.
  */
-class FunctionTypeDescriptor private constructor(mutability: Mutability)
-	: TypeDescriptor(
-		mutability,
-		TypeTag.FUNCTION_TYPE_TAG,
-		TypeTag.FUNCTION_TAG,
-		ObjectSlots::class.java,
-		IntegerSlots::class.java)
+class FunctionTypeDescriptor
+private constructor(
+	mutability: Mutability
+) : TypeDescriptor(
+	mutability,
+	TypeTag.FUNCTION_TYPE_TAG,
+	TypeTag.FUNCTION_TAG,
+	ObjectSlots::class.java,
+	IntegerSlots::class.java)
 {
 	/**
 	 * The layout of integer slots for my instances.
@@ -173,7 +174,8 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 	}
 
 	public override fun allowsImmutableToMutableReferenceInField(
-		e: AbstractSlotsEnum): Boolean = e === HASH_AND_MORE
+		e: AbstractSlotsEnum
+	): Boolean = e === HASH_AND_MORE
 
 	override fun printObjectOnAvoidingIndent(
 		self: AvailObject,
@@ -243,12 +245,12 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 	override fun o_AcceptsArgTypesFromFunctionType(
 		self: AvailObject,
 		functionType: A_Type
-	): Boolean = functionType.argsTupleType.isSubtypeOf(
-		self[ARGS_TUPLE_TYPE])
+	) = functionType.argsTupleType.isSubtypeOf(self[ARGS_TUPLE_TYPE])
 
 	override fun o_AcceptsListOfArgTypes(
 		self: AvailObject,
-		argTypes: List<A_Type>): Boolean
+		argTypes: List<A_Type>
+	): Boolean
 	{
 		val tupleType: A_Type = self[ARGS_TUPLE_TYPE]
 		var i = 1
@@ -266,7 +268,8 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 
 	override fun o_AcceptsListOfArgValues(
 		self: AvailObject,
-		argValues: List<A_BasicObject>): Boolean
+		argValues: List<A_BasicObject>
+	): Boolean
 	{
 		val tupleType: A_Type = self[ARGS_TUPLE_TYPE]
 		var i = 1
@@ -285,7 +288,8 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 
 	override fun o_AcceptsTupleOfArgTypes(
 		self: AvailObject,
-		argTypes: A_Tuple): Boolean
+		argTypes: A_Tuple
+	): Boolean
 	{
 		val tupleType: A_Type = self[ARGS_TUPLE_TYPE]
 		var i = 1
@@ -311,7 +315,8 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 
 	override fun o_CouldEverBeInvokedWith(
 		self: AvailObject,
-		argRestrictions: List<TypeRestriction>): Boolean
+		argRestrictions: List<TypeRestriction>
+	): Boolean
 	{
 		val tupleType: A_Type = self[ARGS_TUPLE_TYPE]
 		return (1..argRestrictions.size).all {
@@ -327,7 +332,8 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 
 	override fun o_EqualsFunctionType(
 		self: AvailObject,
-		aFunctionType: A_Type): Boolean
+		aFunctionType: A_Type
+	): Boolean
 	{
 		when
 		{
@@ -354,39 +360,53 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 		return true
 	}
 
-	override fun o_Hash(self: AvailObject): Int =
-		self.synchronizeIf(isShared) { hash(self) }
+	/**
+	 * The hash value is stored raw in the object's [HASH_OR_ZERO] slot if it
+	 * has been computed, otherwise that slot is zero. If a zero is detected,
+	 * compute the hash and store it in hashOrZero.  If the computation produces
+	 * 0, use another non-zero constant instead.  We don't bother with volatile
+	 * access, because the calculation in multiple threads would produce the
+	 * same answer.
+	 *
+	 * @param self
+	 *   The object.
+	 * @return
+	 *   The hash.
+	 */
+	override fun o_Hash(self: AvailObject): Int
+	{
+		var hash = self[HASH_OR_ZERO]
+		if (hash == 0)
+		{
+			hash = AvailObject.combine4(
+				self[RETURN_TYPE].hash(),
+				self[DECLARED_EXCEPTIONS].hash(),
+				self[ARGS_TUPLE_TYPE].hash(),
+				0x10447107)
+			if (hash == 0) hash = 0x0A2F44AB
+			self[HASH_OR_ZERO] = hash
+		}
+		return hash
+	}
 
 	override fun o_IsSubtypeOf(self: AvailObject, aType: A_Type): Boolean =
 		aType.isSupertypeOfFunctionType(self)
 
 	override fun o_IsSupertypeOfFunctionType(
 		self: AvailObject,
-		aFunctionType: A_Type): Boolean
+		aFunctionType: A_Type
+	): Boolean
 	{
-		if (self.equals(aFunctionType))
-		{
-			return true
-		}
+		if (self.equals(aFunctionType)) return true
 		if (!aFunctionType.returnType.isSubtypeOf(self[RETURN_TYPE]))
-		{
 			return false
-		}
+		// A ⊆ B if everything A can throw was declared by B.
 		val inners: A_Set = self[DECLARED_EXCEPTIONS]
-		// A ⊆ B if everything A can throw was declared by B
-		each_outer@ for (outer in aFunctionType.declaredExceptions)
-		{
-			for (inner in inners)
-			{
-				if (outer.isSubtypeOf(inner))
-				{
-					continue@each_outer
-				}
-			}
-			return false
+		aFunctionType.declaredExceptions.forEach { other ->
+			if (inners.none { inner -> other.isSubtypeOf(inner) }) return false
 		}
-		return self[ARGS_TUPLE_TYPE].isSubtypeOf(
-			aFunctionType.argsTupleType)
+		// Note: Contravariant argument types.
+		return self[ARGS_TUPLE_TYPE].isSubtypeOf(aFunctionType.argsTupleType)
 	}
 
 	override fun o_IsVacuousType(self: AvailObject): Boolean
@@ -414,11 +434,9 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 		aFunctionType: A_Type): A_Type
 	{
 		val tupleTypeUnion =
-			self[ARGS_TUPLE_TYPE].typeUnion(
-				aFunctionType.argsTupleType)
+			self[ARGS_TUPLE_TYPE].typeUnion(aFunctionType.argsTupleType)
 		val returnType =
-			self[RETURN_TYPE].typeIntersection(
-				aFunctionType.returnType)
+			self[RETURN_TYPE].typeIntersection(aFunctionType.returnType)
 		var exceptions = emptySet
 		for (outer in self[DECLARED_EXCEPTIONS])
 		{
@@ -460,8 +478,8 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 
 	@ThreadSafe
 	override fun o_SerializerOperation(
-		self: AvailObject): SerializerOperation =
-			SerializerOperation.FUNCTION_TYPE
+		self: AvailObject
+	): SerializerOperation = SerializerOperation.FUNCTION_TYPE
 
 	override fun o_WriteSummaryTo(self: AvailObject, writer: JSONWriter)
 	{
@@ -559,34 +577,6 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 					append(tempStrings[i])
 				}
 			}
-		}
-
-		/**
-		 * The hash value is stored raw in the object's
-		 * [hashOrZero][IntegerSlots.HASH_OR_ZERO] slot if it has been computed,
-		 * otherwise that slot is zero. If a zero is detected, compute the hash
-		 * and store it in hashOrZero. Note that the hash can (extremely rarely)
-		 * be zero, in which case the hash must be computed on demand every time
-		 * it is requested. Answer the raw hash value.
-		 *
-		 * @param self
-		 *   The object.
-		 * @return
-		 *   The hash.
-		 */
-		private fun hash(self: AvailObject): Int
-		{
-			var hash = self[HASH_OR_ZERO]
-			if (hash == 0)
-			{
-				hash = AvailObject.combine4(
-					self[RETURN_TYPE].hash(),
-					self[DECLARED_EXCEPTIONS].hash(),
-					self[ARGS_TUPLE_TYPE].hash(),
-					0x10447107)
-				self[HASH_OR_ZERO] = hash
-			}
-			return hash
 		}
 
 		/** The mutable [FunctionTypeDescriptor]. */
@@ -696,12 +686,13 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 		 *   [exception&#32;types][ObjectTypeDescriptor] that an instance may
 		 *   raise.
 		 * @return
-		 *  A function type.
+		 *   A function type.
 		 */
 		fun functionTypeFromArgumentTupleType(
 			argsTupleType: A_Type,
 			returnType: A_Type?,
-			exceptionSet: A_Set): A_Type
+			exceptionSet: A_Set,
+		): A_Type
 		{
 			assert(argsTupleType.isTupleType)
 			val exceptionsReduced = normalizeExceptionSet(exceptionSet)
@@ -724,13 +715,18 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 		 *   arguments that instances should accept.
 		 * @param returnType
 		 *  The [type][TypeDescriptor] of value that an instance should produce.
+		 * @param exceptionSet
+		 *   The [set][SetDescriptor] of checked
+		 *   [exception&#32;types][ObjectTypeDescriptor] that an instance may
+		 *   raise.
 		 * @return
 		 *   A function type.
 		 */
 		fun functionType(
 			argTypes: A_Tuple,
 			returnType: A_Type,
-			exceptionSet: A_Set = emptySet): A_Type
+			exceptionSet: A_Set = emptySet
+		): A_Type
 		{
 			val tupleType = tupleTypeForSizesTypesDefaultType(
 				singleInt(argTypes.tupleSize), argTypes, bottom)
@@ -752,8 +748,9 @@ class FunctionTypeDescriptor private constructor(mutability: Mutability)
 		 */
 		fun functionTypeReturning(returnType: A_Type): A_Type =
 			functionTypeFromArgumentTupleType(
-				bottom,
-				returnType,  // TODO: [MvG] Probably should allow any exception.
-				emptySet)
+				argsTupleType = bottom,
+				returnType = returnType,
+				// TODO: [MvG] Probably should allow any exception.
+				exceptionSet = emptySet)
 	}
 }

--- a/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_CREATE_OBJECT.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwo/operation/L2_CREATE_OBJECT.kt
@@ -36,6 +36,7 @@ import avail.descriptor.objects.ObjectLayoutVariant
 import avail.interpreter.levelTwo.L2Instruction
 import avail.interpreter.levelTwo.L2OperandType
 import avail.interpreter.levelTwo.operand.L2ArbitraryConstantOperand
+import avail.interpreter.levelTwo.operand.L2ConstantOperand
 import avail.interpreter.levelTwo.operand.L2ReadBoxedVectorOperand
 import avail.interpreter.levelTwo.operand.L2WriteBoxedOperand
 import avail.optimizer.jvm.JVMTranslator
@@ -51,6 +52,7 @@ import org.objectweb.asm.MethodVisitor
  */
 class L2_CREATE_OBJECT(
 	var variant: L2ArbitraryConstantOperand<ObjectLayoutVariant>,
+	var guaranteedType: L2ConstantOperand,
 	var fieldValues: L2ReadBoxedVectorOperand,
 	var newObject: L2WriteBoxedOperand
 ) : L2Instruction()
@@ -80,6 +82,7 @@ class L2_CREATE_OBJECT(
 	{
 		val theVariant = variant.constant
 		translator.literal(method, theVariant)
+		translator.literal(method, guaranteedType.constant)
 		ObjectDescriptor.createUninitializedObjectMethod.generateCall(method)
 		val fieldSources = fieldValues.elements
 		val limit = fieldSources.size
@@ -87,7 +90,8 @@ class L2_CREATE_OBJECT(
 		{
 			translator.intConstant(method, i + 1)
 			translator.load(method, fieldSources[i].register())
-			ObjectDescriptor.setFieldMethod.generateCall(method) // Returns object for chaining.
+			// Note: returns the object for chaining.
+			ObjectDescriptor.setFieldMethod.generateCall(method)
 		}
 		translator.store(method, newObject.register())
 	}

--- a/avail/src/main/kotlin/avail/interpreter/levelTwoSimple/L2SimpleTranslator.kt
+++ b/avail/src/main/kotlin/avail/interpreter/levelTwoSimple/L2SimpleTranslator.kt
@@ -602,7 +602,7 @@ constructor(
 			restrictions[stackp] = boxedRestrictionForConstant(tuple)
 			return
 		}
-		val types = (stackp downTo  oldStackp).map {
+		val types = (stackp downTo oldStackp).map {
 			restrictions[it].type
 		}
 		val elementType = types.fold(bottom) { a, b -> a.typeUnion(b) }

--- a/avail/src/main/kotlin/avail/interpreter/primitive/objects/P_TupleToObject.kt
+++ b/avail/src/main/kotlin/avail/interpreter/primitive/objects/P_TupleToObject.kt
@@ -72,6 +72,7 @@ import avail.interpreter.Primitive.Flag.CanInline
 import avail.interpreter.Primitive.Flag.CannotFail
 import avail.interpreter.execution.Interpreter
 import avail.interpreter.levelTwo.operand.L2ArbitraryConstantOperand
+import avail.interpreter.levelTwo.operand.L2ConstantOperand
 import avail.interpreter.levelTwo.operand.L2ReadBoxedOperand
 import avail.interpreter.levelTwo.operand.L2ReadBoxedVectorOperand
 import avail.interpreter.levelTwo.operand.TypeRestriction.Companion.boxedRestrictionForType
@@ -209,6 +210,7 @@ object P_TupleToObject : Primitive(1, CannotFail, CanFold, CanInline)
 		generator.addInstruction(
 			L2_CREATE_OBJECT(
 				L2ArbitraryConstantOperand(variant),
+				L2ConstantOperand(typeGuarantee),
 				L2ReadBoxedVectorOperand(sourcesByFieldIndex.map { it!! }),
 				write))
 		callSiteHelper.useAnswer(generator.readBoxed(write))

--- a/avail/src/main/kotlin/avail/optimizer/jvm/JVMTranslator.kt
+++ b/avail/src/main/kotlin/avail/optimizer/jvm/JVMTranslator.kt
@@ -1578,7 +1578,7 @@ class JVMTranslator constructor(
 			val builder = StringBuilder()
 			instructions.forEach { instruction ->
 				val block = instruction.basicBlock()
-				if (instruction == block.instructions()[0])
+				if (instruction.offset == block.instructions()[0].offset)
 				{
 					builder.append("// #")
 					builder.append(instruction.offset)

--- a/avail/src/main/kotlin/avail/serialization/SerializerOperation.kt
+++ b/avail/src/main/kotlin/avail/serialization/SerializerOperation.kt
@@ -127,7 +127,9 @@ import avail.descriptor.numbers.IntegerDescriptor.Companion.fromUnsignedByte
 import avail.descriptor.numbers.IntegerDescriptor.Companion.one
 import avail.descriptor.numbers.IntegerDescriptor.Companion.two
 import avail.descriptor.numbers.IntegerDescriptor.Companion.zero
+import avail.descriptor.objects.ObjectDescriptor
 import avail.descriptor.objects.ObjectDescriptor.Companion.objectFromMap
+import avail.descriptor.objects.ObjectTypeDescriptor
 import avail.descriptor.objects.ObjectTypeDescriptor.Companion.objectTypeFromMap
 import avail.descriptor.phrases.A_Phrase.Companion.argumentsListNode
 import avail.descriptor.phrases.A_Phrase.Companion.argumentsTuple
@@ -1142,9 +1144,8 @@ enum class SerializerOperation constructor(
 	},
 
 	/**
-	 * A [map][MapDescriptor].  Convert it to a tuple (key1, value1, ...
-	 * key```[N]```, value```[N]```) and work with that, converting it back to a
-	 * map when deserializing.
+	 * An Avail [object][ObjectDescriptor], written as a map from field keys
+	 * ([A_Atom]s) to field values.
 	 */
 	OBJECT(32, GENERAL_MAP.named("field map"))
 	{
@@ -1164,9 +1165,8 @@ enum class SerializerOperation constructor(
 	},
 
 	/**
-	 * A [map][MapDescriptor].  Convert it to a tuple (key1, value1, ...
-	 * key```[N]```, value```[N]```) and work with that, converting it back to a
-	 * map when deserializing.
+	 * An Avail [object type][ObjectTypeDescriptor], written as a map from field
+	 * keys ([A_Atom]s) to field types.
 	 */
 	OBJECT_TYPE(33, GENERAL_MAP.named("field type map"))
 	{


### PR DESCRIPTION
- Much of it was due to LongTupleDescriptor and concatenate/append.
- Added a slot in ObjectDescriptor for tracking the guaranteed static
  type at the point of creation.  This is used in L2_CREATE_OBJECT,
  and defaulted to the variant's mostGeneralType for L1 and L2Simple.
  The dispatch tree does not yet make good use of it, other than after
  testing any individual fields that could be decisive.
- Reconstructors still use map -> object conversion, so objects that
  have been reconstructed don't get the same potential speedup that
  the generated constructors do.
- ObjectTypes now contain a cache of TestOutcomes organized by the
  potential type that they're compared to.  The outcome can indicate
  The object type is a supertype of the receiver, disjoint from it,
  or the comparison was not definitive.  ObjectType comparison does
  not yet use this, but object isInstanceOfKind does.